### PR TITLE
Replace deprecated SUPPORT_* constants for HA 2022.5.0

### DIFF
--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -5,6 +5,7 @@ import ynca
 
 from homeassistant.components.media_player import (
     MediaPlayerEntity,
+    MediaPlayerEntityFeature,
     MediaPlayerDeviceClass,
 )
 from homeassistant.components.media_player.const import (
@@ -13,20 +14,6 @@ from homeassistant.components.media_player.const import (
     REPEAT_MODE_ALL,
     REPEAT_MODE_OFF,
     REPEAT_MODE_ONE,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_STEP,
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_SELECT_SOUND_MODE,
-    SUPPORT_PLAY,
-    SUPPORT_PAUSE,
-    SUPPORT_STOP,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_REPEAT_SET,
-    SUPPORT_SHUFFLE_SET,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -43,12 +30,12 @@ from .debounce import debounce
 from .helpers import scale
 
 SUPPORT_YAMAHA_YNCA_BASE = (
-    SUPPORT_VOLUME_SET
-    | SUPPORT_VOLUME_MUTE
-    | SUPPORT_VOLUME_STEP
-    | SUPPORT_TURN_ON
-    | SUPPORT_TURN_OFF
-    | SUPPORT_SELECT_SOURCE
+    MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.VOLUME_MUTE
+    | MediaPlayerEntityFeature.VOLUME_STEP
+    | MediaPlayerEntityFeature.TURN_ON
+    | MediaPlayerEntityFeature.TURN_OFF
+    | MediaPlayerEntityFeature.SELECT_SOURCE
 )
 
 LIMITED_PLAYBACK_CONTROL_SUBUNITS = [
@@ -223,20 +210,20 @@ class YamahaYncaZone(MediaPlayerEntity):
         """Flag of media commands that are supported."""
         supported_commands = SUPPORT_YAMAHA_YNCA_BASE
         if self._zone.soundprg:
-            supported_commands |= SUPPORT_SELECT_SOUND_MODE
+            supported_commands |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
 
         if input_subunit := self._input_subunit():
             if hasattr(input_subunit, "playback"):
-                supported_commands |= SUPPORT_PLAY
-                supported_commands |= SUPPORT_STOP
+                supported_commands |= MediaPlayerEntityFeature.PLAY
+                supported_commands |= MediaPlayerEntityFeature.STOP
                 if input_subunit.id not in LIMITED_PLAYBACK_CONTROL_SUBUNITS:
-                    supported_commands |= SUPPORT_PAUSE
-                    supported_commands |= SUPPORT_NEXT_TRACK
-                    supported_commands |= SUPPORT_PREVIOUS_TRACK
+                    supported_commands |= MediaPlayerEntityFeature.PAUSE
+                    supported_commands |= MediaPlayerEntityFeature.NEXT_TRACK
+                    supported_commands |= MediaPlayerEntityFeature.PREVIOUS_TRACK
             if hasattr(input_subunit, "repeat"):
-                supported_commands |= SUPPORT_REPEAT_SET
+                supported_commands |= MediaPlayerEntityFeature.REPEAT_SET
             if hasattr(input_subunit, "shuffle"):
-                supported_commands |= SUPPORT_SHUFFLE_SET
+                supported_commands |= MediaPlayerEntityFeature.SHUFFLE_SET
         return supported_commands
 
     def turn_on(self):

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
     "name": "Yamaha (YNCA)",
     "render_readme": true,
     "domains": ["media_player"],
-    "homeassistant": "2022.3.0",
+    "homeassistant": "2022.5.0",
     "iot_class": "Local Push"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,1 @@
+homeassistant-stubs==2022.5.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,2 @@
-# homeassistant version: 2022.5.0
-pytest-homeassistant-custom-component==<version for HA 2022.5.0>
-homeassistant-stubs==2022.5.0
+# homeassistant version: 2022.5.2
+pytest-homeassistant-custom-component==0.9.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
-# homeassistant version: 2022.3.7
-pytest-homeassistant-custom-component==0.7.6
-homeassistant-stubs==2022.3.7
+# homeassistant version: 2022.5.0
+pytest-homeassistant-custom-component==<version for HA 2022.5.0>
+homeassistant-stubs==2022.5.0

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -2,26 +2,13 @@
 from unittest.mock import Mock, create_autospec
 
 import pytest
+from homeassistant.components.media_player import MediaPlayerEntityFeature
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     MEDIA_TYPE_MUSIC,
     REPEAT_MODE_ALL,
     REPEAT_MODE_OFF,
     REPEAT_MODE_ONE,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE,
-    SUPPORT_PLAY,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_REPEAT_SET,
-    SUPPORT_SELECT_SOUND_MODE,
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_SHUFFLE_SET,
-    SUPPORT_STOP,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_STEP,
 )
 from homeassistant.const import (
     STATE_IDLE,
@@ -126,7 +113,7 @@ async def test_mediaplayer_entity_source(mock_zone, mock_receiver):
     assert mock_zone.input == "INPUT_ID_2"
     assert mp_entity.source == "Input Name 2"
 
-    mp_entity.select_source("invalid source") # does not change current source
+    mp_entity.select_source("invalid source")  # does not change current source
     assert mock_zone.input == "INPUT_ID_2"
     assert mp_entity.source == "Input Name 2"
 
@@ -165,19 +152,19 @@ async def test_mediaplayer_entity_supported_features(
 ):
 
     expected_supported_features = (
-        SUPPORT_VOLUME_SET
-        | SUPPORT_VOLUME_MUTE
-        | SUPPORT_VOLUME_STEP
-        | SUPPORT_TURN_ON
-        | SUPPORT_TURN_OFF
-        | SUPPORT_SELECT_SOURCE
+        MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.SELECT_SOURCE
     )
 
     mock_zone.soundprg = None
     assert mp_entity.supported_features == expected_supported_features
 
     mock_zone.soundprg = "DspSoundProgram"
-    expected_supported_features |= SUPPORT_SELECT_SOUND_MODE
+    expected_supported_features |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
     assert mp_entity.supported_features == expected_supported_features
 
     # Sources with `playback` attribute support playback controls
@@ -187,8 +174,8 @@ async def test_mediaplayer_entity_supported_features(
         ynca.netradio.NetRadio, id=ynca.Subunit.NETRADIO
     )
     mock_zone.input = "NET RADIO"
-    expected_supported_features |= SUPPORT_PLAY
-    expected_supported_features |= SUPPORT_STOP
+    expected_supported_features |= MediaPlayerEntityFeature.PLAY
+    expected_supported_features |= MediaPlayerEntityFeature.STOP
     assert mp_entity.supported_features == expected_supported_features
 
     # Other sources also support pausem previous, next
@@ -196,12 +183,12 @@ async def test_mediaplayer_entity_supported_features(
         ynca.mediaplayback_subunits.Usb, id=ynca.Subunit.USB
     )
     mock_zone.input = "USB"
-    expected_supported_features |= SUPPORT_PAUSE
-    expected_supported_features |= SUPPORT_PREVIOUS_TRACK
-    expected_supported_features |= SUPPORT_NEXT_TRACK
+    expected_supported_features |= MediaPlayerEntityFeature.PAUSE
+    expected_supported_features |= MediaPlayerEntityFeature.PREVIOUS_TRACK
+    expected_supported_features |= MediaPlayerEntityFeature.NEXT_TRACK
     # USB also supports repeat and shuffle
-    expected_supported_features |= SUPPORT_REPEAT_SET
-    expected_supported_features |= SUPPORT_SHUFFLE_SET
+    expected_supported_features |= MediaPlayerEntityFeature.REPEAT_SET
+    expected_supported_features |= MediaPlayerEntityFeature.SHUFFLE_SET
 
     assert mp_entity.supported_features == expected_supported_features
 


### PR DESCRIPTION
In HA 2022.5 SUPPORT_* constants are deprecated. For more details see: https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/

This PR prepares for that change.
All code changes are done, but can not yet be merged because of dependencies

* Requires HA 2022.5.0 so that needs to be released
* pytest-homeassistant-custom-component needs to be updated