### PR TITLE
Protect against changed modelinfo

### DIFF
--- a/custom_components/yamaha_ynca/__init__.py
+++ b/custom_components/yamaha_ynca/__init__.py
@@ -74,7 +74,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     # to increase the VERSION of the YamahaYncaConfigFlow
 
     LOGGER.info(
-        "Migration from ConfigEntry version %s to version %s successful",
+        "Migration of ConfigEntry from version %s to version %s successful",
         from_version,
         config_entry.version,
     )

--- a/custom_components/yamaha_ynca/__init__.py
+++ b/custom_components/yamaha_ynca/__init__.py
@@ -84,14 +84,16 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
 def migrate_v3(hass: HomeAssistant, config_entry: ConfigEntry):
     # Changed how hidden soundmodes are stored
-    # Used to the the enum name, now it is the value
+    # Used to be the enum name, now it is the value
 
     options = dict(config_entry.options)
     if old_hidden_soundmodes := options.get(CONF_HIDDEN_SOUND_MODES, None):
-        new_hidden_soundmodes = [
-            ynca.SoundPrg[old_hidden_soundmode].value
-            for old_hidden_soundmode in old_hidden_soundmodes
-        ]
+        new_hidden_soundmodes = []
+        for old_hidden_soundmode in old_hidden_soundmodes:
+            try:
+                new_hidden_soundmodes.append(ynca.SoundPrg[old_hidden_soundmode].value)
+            except KeyError:
+                pass
         options[CONF_HIDDEN_SOUND_MODES] = new_hidden_soundmodes
 
     config_entry.version = 4
@@ -187,6 +189,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # hass.services.call(
         #     HA_DOMAIN, SERVICE_RELOAD_CONFIG_ENTRY, {"entry_id": entry.entry_id}
         # )
+
+    hass.config_entries.async_update_entry(entry, data=entry.data)
 
     ynca_receiver = ynca.Ynca(
         serial_url_from_user_input(entry.data[CONF_SERIAL_URL]),

--- a/custom_components/yamaha_ynca/config_flow.py
+++ b/custom_components/yamaha_ynca/config_flow.py
@@ -175,17 +175,27 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         modelinfo = ynca.get_modelinfo(api.SYS.modelname)
 
         # Hiding sound modes
-        sound_modes = {}
+        sound_modes = []
         for sound_mode in ynca.SoundPrg:
             if modelinfo and not sound_mode in modelinfo.soundprg:
                 continue  # Skip soundmodes not supported on the model
-            sound_modes[sound_mode.value] = sound_mode.value
-        sound_modes = dict(sorted(sound_modes.items(), key=lambda tup: tup[1]))
+            # sound_modes[sound_mode.value] = sound_mode.value
+            sound_modes.append(sound_mode.value)
+        # sound_modes = dict(sorted(sound_modes.items(), key=lambda tup: tup[1]))
+        sound_modes.sort(key=str.lower)
+
+        # Protect against supported soundmode list updates
+        stored_sound_modes = self.config_entry.options.get(CONF_HIDDEN_SOUND_MODES, [])
+        stored_sound_modes = [
+            stored_sound_mode
+            for stored_sound_mode in stored_sound_modes
+            if stored_sound_mode in sound_modes
+        ]
 
         schema[
             vol.Required(
                 CONF_HIDDEN_SOUND_MODES,
-                default=self.config_entry.options.get(CONF_HIDDEN_SOUND_MODES, []),
+                default=stored_sound_modes,
             )
         ] = cv.multi_select(sound_modes)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -158,6 +158,11 @@ async def test_options_flow(hass: HomeAssistant, mock_ynca) -> None:
         ],
     ):
         integration = await setup_integration(hass, mock_ynca, modelname="RX-A810")
+        options = dict(integration.entry.options)
+        options[yamaha_ynca.const.CONF_HIDDEN_SOUND_MODES] = [
+            "UNSUPPORTED",  # Test that obsolete values don't break the schema
+        ]
+        integration.entry.options = options
 
         result = await hass.config_entries.options.async_init(
             integration.entry.entry_id
@@ -171,7 +176,9 @@ async def test_options_flow(hass: HomeAssistant, mock_ynca) -> None:
             user_input={
                 yamaha_ynca.const.CONF_HIDDEN_INPUTS_FOR_ZONE("MAIN"): ["INPUT_ID_1"],
                 yamaha_ynca.const.CONF_HIDDEN_INPUTS_FOR_ZONE("ZONE2"): ["INPUT_ID_2"],
-                yamaha_ynca.const.CONF_HIDDEN_SOUND_MODES: ["Hall in Vienna"],
+                yamaha_ynca.const.CONF_HIDDEN_SOUND_MODES: [
+                    "Hall in Vienna",
+                ],
             },
         )
 

--- a/tests/test_init_migrate.py
+++ b/tests/test_init_migrate.py
@@ -114,7 +114,7 @@ async def test_async_migration_entry_version_3_hidden_soundmodes(hass: HomeAssis
         entry_id="entry_id",
         title="ModelName",
         data={"serial_url": "SerialUrl"},
-        options={CONF_HIDDEN_SOUND_MODES: ["CHURCH_IN_ROYAUMONT"]},
+        options={CONF_HIDDEN_SOUND_MODES: ["CHURCH_IN_ROYAUMONT", "UNSUPPORTED"]},
         version=3,
     )
     old_entry.add_to_hass(hass)


### PR DESCRIPTION
Modelinfo can be updated at any ynca update.
Make sure that changed modelinfo does not result in errors (currently only related to Soundmodes)