### PR TITLE
Use idle state instead of on

### DIFF
--- a/custom_components/yamaha_ynca/config_flow.py
+++ b/custom_components/yamaha_ynca/config_flow.py
@@ -179,9 +179,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         for sound_mode in ynca.SoundPrg:
             if modelinfo and not sound_mode in modelinfo.soundprg:
                 continue  # Skip soundmodes not supported on the model
-            # sound_modes[sound_mode.value] = sound_mode.value
             sound_modes.append(sound_mode.value)
-        # sound_modes = dict(sorted(sound_modes.items(), key=lambda tup: tup[1]))
         sound_modes.sort(key=str.lower)
 
         # Protect against supported soundmode list updates

--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -162,9 +162,9 @@ class YamahaYncaZone(MediaPlayerEntity):
             if playbackinfo == ynca.PlaybackInfo.PAUSE:
                 return MediaPlayerState.PAUSED
             if playbackinfo == ynca.PlaybackInfo.STOP:
-                return MediaPlayerState.ON
+                return MediaPlayerState.IDLE
 
-        return MediaPlayerState.ON
+        return MediaPlayerState.IDLE
 
     @property
     def volume_level(self):

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -71,7 +71,7 @@ async def test_mediaplayer_entity_turn_on_off(
 ):
     mp_entity.turn_on()
     assert mock_zone.pwr == True
-    assert mp_entity.state == MediaPlayerState.ON
+    assert mp_entity.state == MediaPlayerState.IDLE
 
     mp_entity.turn_off()
     assert mock_zone.pwr == False
@@ -259,7 +259,7 @@ async def test_mediaplayer_entity_state(
     assert mp_entity.state == MediaPlayerState.OFF
 
     mock_zone.pwr = True
-    assert mp_entity.state == MediaPlayerState.ON
+    assert mp_entity.state == MediaPlayerState.IDLE
 
     mock_zone.inp = "USB"
     mock_ynca.USB = create_autospec(
@@ -273,7 +273,7 @@ async def test_mediaplayer_entity_state(
     assert mp_entity.state == MediaPlayerState.PAUSED
 
     mock_ynca.USB.playbackinfo = ynca.PlaybackInfo.STOP
-    assert mp_entity.state == MediaPlayerState.ON
+    assert mp_entity.state == MediaPlayerState.IDLE
 
 
 async def test_mediaplayer_playback_controls(mp_entity, mock_zone):


### PR DESCRIPTION
Use Idle state instead of On.

ON should only be used when no more detailed state is available. Since the mediaplayer can also be Playing or Paused the use of Idle is needed.

This fixes #54 