### PR TITLE
Change translation keys to snake_case

### DIFF
--- a/custom_components/yamaha_ynca/strings.json
+++ b/custom_components/yamaha_ynca/strings.json
@@ -87,19 +87,19 @@
     "select": {
       "hdmiout": {
         "state": {
-          "Off": "Off",
-          "OUT1": "HDMI OUT 1",
-          "OUT2": "HDMI OUT 2",
-          "OUT1 + 2": "Both"
+          "off": "Off",
+          "out1": "HDMI OUT 1",
+          "out2": "HDMI OUT 2",
+          "out1_2": "HDMI OUT 1 + 2"
         }
       },
       "sleep": {
         "state": {
-          "Off": "Off",
-          "30 min": "30 Minutes",
-          "60 min": "60 Minutes",
-          "90 min": "90 Minutes",
-          "120 min": "120 Minutes"
+          "off": "Off",
+          "30_min": "30 Minutes",
+          "60_min": "60 Minutes",
+          "90_min": "90 Minutes",
+          "120_min": "120 Minutes"
         }
       }
     }

--- a/custom_components/yamaha_ynca/translations/en.json
+++ b/custom_components/yamaha_ynca/translations/en.json
@@ -87,19 +87,19 @@
     "select": {
       "hdmiout": {
         "state": {
-          "Off": "Off",
-          "OUT1": "HDMI OUT 1",
-          "OUT2": "HDMI OUT 2",
-          "OUT1 + 2": "Both"
+          "off": "Off",
+          "out1": "HDMI OUT 1",
+          "out2": "HDMI OUT 2",
+          "out1_2": "HDMI OUT 1 + 2"
         }
       },
       "sleep": {
         "state": {
-          "Off": "Off",
-          "30 min": "30 Minutes",
-          "60 min": "60 Minutes",
-          "90 min": "90 Minutes",
-          "120 min": "120 Minutes"
+          "off": "Off",
+          "30_min": "30 Minutes",
+          "60_min": "60 Minutes",
+          "90_min": "90 Minutes",
+          "120_min": "120 Minutes"
         }
       }
     }

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -10,6 +10,7 @@ from custom_components.yamaha_ynca.select import (
     YamahaYncaSelect,
     YncaSelectEntityDescription,
     async_setup_entry,
+    build_enum_options_list,
 )
 from homeassistant.helpers.entity import EntityCategory
 
@@ -22,7 +23,7 @@ TEST_ENTITY_DESCRIPTION = YncaSelectEntityDescription(  # type: ignore
     enum=ynca.HdmiOut,
     icon="mdi:hdmi-port",
     name="HDMI Out",
-    options=[e.value for e in ynca.HdmiOut],
+    options=build_enum_options_list(ynca.HdmiOut),
 )
 
 
@@ -64,13 +65,13 @@ async def test_select_entity_fields(mock_zone):
     }
 
     # Setting value
-    entity.select_option("Off")
+    entity.select_option("off")
     assert mock_zone.hdmiout is ynca.HdmiOut.OFF
-    entity.select_option("OUT1 + 2")
+    entity.select_option("out1_2")
     assert mock_zone.hdmiout is ynca.HdmiOut.OUT1_PLUS_2
 
     # Reading state
     mock_zone.hdmiout = ynca.HdmiOut.OUT1
-    assert entity.current_option == "OUT1"
+    assert entity.current_option == "out1"
     mock_zone.hdmiout = ynca.HdmiOut.OUT2
-    assert entity.current_option == "OUT2"
+    assert entity.current_option == "out2"


### PR DESCRIPTION
According to info in this PR https://github.com/home-assistant/core/pull/85221 translationkeys should be in snake_case (or with a hyphen). So lets fix it.