### PR TITLE
Remove integration type

### DIFF
--- a/custom_components/yamaha_ynca/manifest.json
+++ b/custom_components/yamaha_ynca/manifest.json
@@ -8,7 +8,6 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/mvdwetering/yamaha_ynca",
-  "integration_type": "hub",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mvdwetering/yamaha_ynca/issues",
   "loggers": ["ynca"],


### PR DESCRIPTION
Remove integration type from manifest. Using "hub" (which matches best with how the integration is organize) it only seems to control the text on the integration page to "Add hub" which annoys me as a receiver is not really  a hub, 

Removing it changes the text to "Add entry" which is better.

Keep an eye on this discussion in Architecture repo about subdevices which is more fitting for this integration https://github.com/home-assistant/architecture/discussions/957