### PR TITLE
Don't pass hass to entity

### DIFF
--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -50,7 +50,6 @@ async def async_setup_entry(hass, config_entry: ConfigEntry, async_add_entities)
 
             entities.append(
                 YamahaYncaZone(
-                    hass,
                     config_entry.entry_id,
                     domain_entry_data.api,
                     zone_subunit,
@@ -72,14 +71,12 @@ class YamahaYncaZone(MediaPlayerEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         receiver_unique_id: str,
         ynca: ynca.YncaApi,
         zone: ZoneBase,
         hidden_inputs: List[str],
         hidden_sound_modes: List[str],
     ):
-        self._hass = hass
         self._ynca = ynca
         self._zone = zone
         self._hidden_inputs = hidden_inputs
@@ -96,7 +93,7 @@ class YamahaYncaZone(MediaPlayerEntity):
         if function == "ZONENAME":
             # Note that the mediaplayer does not have a name since it uses the devicename
             # So update the device name when the zonename changes to keep names as expected
-            registry = device_registry.async_get(self._hass)
+            registry = device_registry.async_get(self.hass)
             device = registry.async_get_device(identifiers={(DOMAIN, self._device_id)})
             if device:
                 devicename = build_devicename(self._ynca, self._zone)

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -114,7 +114,7 @@ async def test_mediaplayer_entity_update_callback_zonename(
     # Zonename update
     mock_zone.zonename = "New Zonename"
     zone_callback("ZONENAME", "VALUE")  # Note VALUE is not used it is read from API
-    zone_entity.schedule_update_ha_state.call_count == 1
+    assert zone_entity.schedule_update_ha_state.call_count == 1
 
     # Check for name change
     device_entry = device_reg.async_get_or_create(

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -20,8 +20,8 @@ from tests.conftest import setup_integration
 
 
 @pytest.fixture
-def mp_entity(hass, mock_zone, mock_ynca) -> YamahaYncaZone:
-    return YamahaYncaZone(hass, "ReceiverUniqueId", mock_ynca, mock_zone, [], [])
+def mp_entity(mock_zone, mock_ynca) -> YamahaYncaZone:
+    return YamahaYncaZone("ReceiverUniqueId", mock_ynca, mock_zone, [], [])
 
 
 @patch("custom_components.yamaha_ynca.media_player.YamahaYncaZone", autospec=True)
@@ -44,9 +44,9 @@ async def test_async_setup_entry(
     yamahayncazone_mock.assert_has_calls(
         [
             call(
-                hass, "entry_id", mock_ynca, mock_ynca.main, ["Airplay"], ["Adventure"]
+                "entry_id", mock_ynca, mock_ynca.main, ["Airplay"], ["Adventure"]
             ),
-            call(hass, "entry_id", mock_ynca, mock_ynca.zone2, [], ["Adventure"]),
+            call("entry_id", mock_ynca, mock_ynca.zone2, [], ["Adventure"]),
         ]
     )
 
@@ -88,7 +88,7 @@ async def test_mediaplayer_entity(mp_entity: YamahaYncaZone, mock_zone, mock_ync
 
 
 async def test_mediaplayer_entity_update_callback_zonename(
-    mock_zone, mock_ynca, device_reg, hass
+    mock_zone, mock_ynca, hass, device_reg
 ):
     # Setup integration, device registry and entiry
     mock_ynca.main = mock_zone
@@ -100,12 +100,14 @@ async def test_mediaplayer_entity_update_callback_zonename(
         name="Old Zonename",
     )
 
-    zone_entity = YamahaYncaZone(hass, "ReceiverUniqueId", mock_ynca, mock_zone, [], [])
+    zone_entity = YamahaYncaZone("ReceiverUniqueId", mock_ynca, mock_zone, [], [])
     assert zone_entity.device_info["identifiers"] == {
         (yamaha_ynca.DOMAIN, "ReceiverUniqueId_ZoneId")
     }
 
+    zone_entity.hass = hass  # In a real system this is done by HA
     await zone_entity.async_added_to_hass()
+
     zone_callback = mock_zone.register_update_callback.call_args.args[0]
     zone_entity.schedule_update_ha_state = Mock()
 
@@ -194,7 +196,7 @@ async def test_mediaplayer_entity_source(hass, mock_zone, mock_ynca):
     mock_ynca.sys.inpnamehdmi4 = "Input HDMI 4"
 
     mp_entity = YamahaYncaZone(
-        hass, "ReceiverUniqueId", mock_ynca, mock_zone, ["TUNER"], []
+        "ReceiverUniqueId", mock_ynca, mock_zone, ["TUNER"], []
     )
 
     # Select a rename-able source
@@ -233,7 +235,7 @@ async def test_mediaplayer_entity_source_list(hass, mock_zone, mock_ynca):
 
     # Tuner is hidden
     mp_entity = YamahaYncaZone(
-        hass, "ReceiverUniqueId", mock_ynca, mock_zone, ["TUNER"], []
+        "ReceiverUniqueId", mock_ynca, mock_zone, ["TUNER"], []
     )
 
     assert mp_entity.source_list == ["Input HDMI 4", "NET RADIO"]
@@ -248,7 +250,7 @@ async def test_mediaplayer_entity_source_whitespace_handling(
     mock_ynca.sys.inpnamehdmi3 = "Trailing spaces   "
     mock_ynca.sys.inpnamehdmi4 = "   Leading and trailing spaces   "
 
-    mp_entity = YamahaYncaZone(hass, "ReceiverUniqueId", mock_ynca, mock_zone, [], [])
+    mp_entity = YamahaYncaZone("ReceiverUniqueId", mock_ynca, mock_zone, [], [])
 
     assert mp_entity.source_list == unordered(
         [
@@ -338,7 +340,7 @@ async def test_mediaplayer_entity_hidden_sound_mode(hass, mock_ynca, mock_zone):
     mock_zone.soundprg = ynca.SoundPrg.VILLAGE_VANGUARD
 
     mp_entity = YamahaYncaZone(
-        hass, "ReceiverUniqueId", mock_ynca, mock_zone, [], ["MONO_MOVIE"]
+        "ReceiverUniqueId", mock_ynca, mock_zone, [], ["MONO_MOVIE"]
     )
 
     assert "Drama" in mp_entity.sound_mode_list

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -90,7 +90,7 @@ async def test_mediaplayer_entity(mp_entity: YamahaYncaZone, mock_zone, mock_ync
 async def test_mediaplayer_entity_update_callback_zonename(
     mock_zone, mock_ynca, hass, device_reg
 ):
-    # Setup integration, device registry and entiry
+    # Setup integration, device registry and entity
     mock_ynca.main = mock_zone
     integration = await setup_integration(hass, mock_ynca)
 


### PR DESCRIPTION
Improve code by not passing hass to entity as it will be set by HA. See 4.2 https://developers.home-assistant.io/docs/creating_platform_code_review/#4-entity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the media player component by removing unnecessary `hass` parameter in the setup and class constructor.
  - Updated tests to align with the refactored media player component structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->