### PR TITLE
Don't record "commands" attribute in  recorder

### DIFF
--- a/custom_components/yamaha_ynca/const.py
+++ b/custom_components/yamaha_ynca/const.py
@@ -14,6 +14,7 @@ CONF_PORT = "port"
 DATA_MODELNAME = "modelname"
 DATA_ZONES = "zones"
 
+ATTR_COMMANDS = "commands"
 
 MANUFACTURER_NAME = "Yamaha"
 

--- a/custom_components/yamaha_ynca/remote.py
+++ b/custom_components/yamaha_ynca/remote.py
@@ -7,6 +7,7 @@ from homeassistant.components.remote import RemoteEntity
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import (
+    ATTR_COMMANDS,
     DOMAIN,
     ZONE_ATTRIBUTE_NAMES,
 )
@@ -116,6 +117,8 @@ class YamahaYncaZoneRemote(RemoteEntity):
     )
     _attr_has_entity_name = True
     _attr_entity_registry_enabled_default = False
+    
+    _unrecorded_attributes = frozenset({ATTR_COMMANDS})
 
     def __init__(
         self,
@@ -134,7 +137,7 @@ class YamahaYncaZoneRemote(RemoteEntity):
             identifiers={(DOMAIN, f"{receiver_unique_id}_{zone.id}")}
         )
 
-        self._attr_extra_state_attributes = {"commands": list(self._zone_codes.keys())}
+        self._attr_extra_state_attributes = {ATTR_COMMANDS: list(self._zone_codes.keys())}
 
     def _format_remotecode(self, input_code: str) -> str:
         """

--- a/custom_components/yamaha_ynca/remote.py
+++ b/custom_components/yamaha_ynca/remote.py
@@ -117,7 +117,6 @@ class YamahaYncaZoneRemote(RemoteEntity):
     )
     _attr_has_entity_name = True
     _attr_entity_registry_enabled_default = False
-    
     _unrecorded_attributes = frozenset({ATTR_COMMANDS})
 
     def __init__(


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Exclude "commands"  attribute from recorder.

- **Refactor**
  - Improved code consistency by using a constant for the 'commands' attribute in the Yamaha remote component.

- **Style**
  - Codebase updated to align with best practices for maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->