### PR TITLE
Hide AUDIO input for existing users

### DIFF
--- a/custom_components/yamaha_ynca/__init__.py
+++ b/custom_components/yamaha_ynca/__init__.py
@@ -166,7 +166,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await update_device_registry(hass, entry, ynca_receiver)
         await update_configentry(hass, entry, ynca_receiver)
 
-        if receiver_requires_audio_input_workaround(ynca_receiver):
+        assert(ynca_receiver.sys is not None)
+        if receiver_requires_audio_input_workaround(ynca_receiver.sys.modelname):
             # Pretend AUDIO provides a name like a normal input
             # This makes it work with standard code
             ynca_receiver.sys.inpnameaudio = "AUDIO"  # type: ignore

--- a/custom_components/yamaha_ynca/config_flow.py
+++ b/custom_components/yamaha_ynca/config_flow.py
@@ -74,6 +74,7 @@ class YamahaYncaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     # When updating also update the one used in `setup_integration` for tests
     VERSION = 7
+    MINOR_VERSION = 2
 
     reauth_entry: config_entries.ConfigEntry | None = None
 

--- a/custom_components/yamaha_ynca/helpers.py
+++ b/custom_components/yamaha_ynca/helpers.py
@@ -34,13 +34,11 @@ def scale(input_value, input_range, output_range):
     return output_min + (value_scaled * output_spread)
 
 
-def receiver_requires_audio_input_workaround(api:ynca.api.YncaApi) -> bool:
-    if api.sys:
-        # These models do not report the (single) AUDIO input properly
-        # Only confirmed on RX-V475, but the others share the same firmware
-        # See https://github.com/mvdwetering/yamaha_ynca/issues/230
-        return api.sys.modelname in ["RX-V475", "RX-V575", "HTR-4066", "HTR-5066"]
-    return False # pragma: no cover
+def receiver_requires_audio_input_workaround(modelname) -> bool:
+    # These models do not report the (single) AUDIO input properly
+    # Only confirmed on RX-V475, but the others share the same firmware
+    # See https://github.com/mvdwetering/yamaha_ynca/issues/230
+    return modelname in ["RX-V475", "RX-V575", "HTR-4066", "HTR-5066"]
 
 class YamahaYncaSettingEntity:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry, entity_registry
 
-from pytest_homeassistant_custom_component.common import (
+from pytest_homeassistant_custom_component.common import (  # type: ignore[import]
     MockConfigEntry,
     mock_device_registry,
 )
@@ -191,6 +191,7 @@ async def setup_integration(
 
     entry = MockConfigEntry(
         version=7,
+        minor_version=2,
         domain=yamaha_ynca.DOMAIN,
         entry_id="entry_id",
         title=MODELNAME,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -82,6 +82,19 @@ async def test_async_setup_entry_audio_input_workaround_applied(
 
     assert mock_ynca.sys.inpnameaudio == "AUDIO"
 
+async def test_async_setup_entry_audio_input_workaround_not_applied(
+    hass, device_reg, mock_ynca, mock_zone_main
+):
+    """Test a successful setup entry."""
+    mock_ynca.main = mock_zone_main
+    mock_ynca.sys.modelname = "RX-A6A"
+
+    integration = await setup_integration(
+        hass, mock_ynca
+    )
+
+    assert getattr(mock_ynca.sys, "inpnameaudio", None) is None
+
 
 async def test_async_setup_entry_fails_with_connection_error(hass, mock_ynca):
     """Test a successful setup entry."""


### PR DESCRIPTION
Receivers that do _not_ allow for input detection show all inputs, but with the AUDIO input workaround for RX-V475 and others it will cause the audio input to also show up in the source list.

Explicitly hide the AUDIO input for everyone not needing the workaround. If needed can still be unhidden manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the process for determining if a Yamaha receiver requires an audio input workaround.
	- Added a migration function to update configurations for certain Yamaha receivers, hiding unnecessary audio inputs.

- **Bug Fixes**
	- Ensured the system checks for `None` values to prevent errors during the audio input workaround process.

- **Tests**
	- Introduced tests to validate the new migration process and the correct application of audio input workarounds.
	- Added a minor version attribute to test configurations to support migration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->