### PR TITLE
Also apply AUDIO workaround for RX-V473, RX-V573, HTR-4065, HTR-5065

### DIFF
--- a/custom_components/yamaha_ynca/helpers.py
+++ b/custom_components/yamaha_ynca/helpers.py
@@ -45,7 +45,7 @@ def receiver_requires_audio_input_workaround(modelname) -> bool:
         "RX-V475",
         "RX-V575",
         "HTR-4066",
-        "HTR-5066",  
+        "HTR-5066",
         "RX-V473",
         "RX-V573",
         "HTR-4065",

--- a/custom_components/yamaha_ynca/helpers.py
+++ b/custom_components/yamaha_ynca/helpers.py
@@ -1,4 +1,5 @@
 """Helpers for the Yamaha (YNCA) integration."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -36,9 +37,21 @@ def scale(input_value, input_range, output_range):
 
 def receiver_requires_audio_input_workaround(modelname) -> bool:
     # These models do not report the (single) AUDIO input properly
-    # Only confirmed on RX-V475, but the others share the same firmware
+    # Reported for RX-V475, including RX-V575, HTR-4066, HTR-5066 because they share firmware
     # See https://github.com/mvdwetering/yamaha_ynca/issues/230
-    return modelname in ["RX-V475", "RX-V575", "HTR-4066", "HTR-5066"]
+    # Also for RX-V473, including RX-V573, HTR-4065, HTR-5065 because they share firmware
+    # See https://github.com/mvdwetering/yamaha_ynca/discussions/234
+    return modelname in [
+        "RX-V475",
+        "RX-V575",
+        "HTR-4066",
+        "HTR-5066",  
+        "RX-V473",
+        "RX-V573",
+        "HTR-4065",
+        "HTR-5065",
+    ]
+
 
 class YamahaYncaSettingEntity:
     """
@@ -49,14 +62,18 @@ class YamahaYncaSettingEntity:
     _attr_has_entity_name = True
 
     def __init__(
-        self, receiver_unique_id, subunit: SubunitBase, description: EntityDescription, associated_zone: ZoneBase | None = None
+        self,
+        receiver_unique_id,
+        subunit: SubunitBase,
+        description: EntityDescription,
+        associated_zone: ZoneBase | None = None,
     ):
         self.entity_description = description
         self._subunit = subunit
 
         if associated_zone is None:
-            if TYPE_CHECKING:   # pragma: no cover
-                assert(isinstance(subunit, ZoneBase))
+            if TYPE_CHECKING:  # pragma: no cover
+                assert isinstance(subunit, ZoneBase)
             associated_zone = subunit
         self._associated_zone = associated_zone
 
@@ -73,7 +90,7 @@ class YamahaYncaSettingEntity:
         self._attr_device_info: DeviceInfo | None = DeviceInfo(
             identifiers={(DOMAIN, f"{receiver_unique_id}_{self._associated_zone.id}")}
         )
-        self._attr_translation_key: str | None = self.entity_description.key 
+        self._attr_translation_key: str | None = self.entity_description.key
         self._attr_unique_id: str | None = (
             f"{self._receiver_unique_id_subunit_id}_{self.entity_description.key}"
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded support in audio input workaround to include models RX-V473, RX-V573, HTR-4065, and HTR-5065.
- **Refactor**
	- Improved code readability and future compatibility through the use of future annotations and type hints in the Yamaha YNCA integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->