### PR TITLE
Add service to store presets

### DIFF
--- a/custom_components/yamaha_ynca/__init__.py
+++ b/custom_components/yamaha_ynca/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     DOMAIN,
     LOGGER,
     MANUFACTURER_NAME,
+    SERVICE_SEND_RAW_YNCA,
     ZONE_ATTRIBUTE_NAMES,
 )
 from .helpers import DomainEntryData, receiver_requires_audio_input_workaround
@@ -34,9 +35,6 @@ PLATFORMS: List[Platform] = [
     Platform.SWITCH,
     Platform.REMOTE,
 ]
-
-SERVICE_SEND_RAW_YNCA = "send_raw_ynca"
-
 
 async def update_device_registry(
     hass: HomeAssistant, config_entry: ConfigEntry, receiver: ynca.YncaApi

--- a/custom_components/yamaha_ynca/const.py
+++ b/custom_components/yamaha_ynca/const.py
@@ -16,7 +16,11 @@ CONF_PORT = "port"
 DATA_MODELNAME = "modelname"
 DATA_ZONES = "zones"
 
+SERVICE_SEND_RAW_YNCA = "send_raw_ynca"
+SERVICE_STORE_PRESET = "store_preset"
+
 ATTR_COMMANDS = "commands"
+ATTR_PRESET_ID = "preset_id"
 
 MANUFACTURER_NAME = "Yamaha"
 

--- a/custom_components/yamaha_ynca/icons.json
+++ b/custom_components/yamaha_ynca/icons.json
@@ -1,5 +1,6 @@
 {
     "services": {
-        "send_raw_ynca": "mdi:raw"
+        "send_raw_ynca": "mdi:raw",
+        "store_preset": "mdi:star"
     }
 }

--- a/custom_components/yamaha_ynca/input_helpers.py
+++ b/custom_components/yamaha_ynca/input_helpers.py
@@ -62,7 +62,7 @@ input_mappings: List[Mapping] = [
 
 class InputHelper:
     @staticmethod
-    def get_subunit_for_input(api: ynca.YncaApi, input: ynca.Input):
+    def get_subunit_for_input(api: ynca.YncaApi, input: ynca.Input | None):
         """Returns Subunit of the current provided input if possible, otherwise None"""
         for mapping in input_mappings:
             if mapping.ynca_input is input:

--- a/custom_components/yamaha_ynca/services.yaml
+++ b/custom_components/yamaha_ynca/services.yaml
@@ -14,3 +14,18 @@ send_raw_ynca:
       selector:
         text:
           multiline: true
+
+store_preset:
+  target:
+    entity:
+      integration: yamaha_ynca
+      domain: media_player
+  fields:
+    preset_id:
+      example: "12"
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 40
+          mode: box

--- a/custom_components/yamaha_ynca/strings.json
+++ b/custom_components/yamaha_ynca/strings.json
@@ -207,6 +207,16 @@
           "description": "Raw YNCA data to send. One command per line. Needs to follow YNCA format @SUBUNIT:FUNCTION=VALUE"
         }
       }
+    },
+    "store_preset": {
+      "name": "Store preset",
+      "description": "Store a preset for the current input.",
+      "fields": {
+        "preset_id": {
+          "name": "Preset ID",
+          "description": "Preset ID to store, must be in range 1 to 40"
+        }
+      }
     }
   }
 }

--- a/custom_components/yamaha_ynca/translations/en.json
+++ b/custom_components/yamaha_ynca/translations/en.json
@@ -207,6 +207,16 @@
           "description": "Raw YNCA data to send. One command per line. Needs to follow YNCA format @SUBUNIT:FUNCTION=VALUE"
         }
       }
+    },
+    "store_preset": {
+      "name": "Store preset",
+      "description": "Store a preset for the current input.",
+      "fields": {
+        "preset_id": {
+          "name": "Preset ID",
+          "description": "Preset ID to store, must be in range 1 to 40"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new service to send raw YNCA commands to devices.
	- Added a feature to store presets on devices.
- **Enhancements**
	- Improved input handling to accept `None` as a value, enhancing flexibility.
	- Enhanced media browsing and playing capabilities for a better user experience.
- **Bug Fixes**
	- Fixed issues related to service registration and implementation for a smoother operation.
- **Tests**
	- Updated test suite to cover new functionalities and ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->