### PR TITLE
Some preset tweaks

### DIFF
--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -291,10 +291,28 @@ class YamahaYncaZone(MediaPlayerEntity):
                 supported_commands |= MediaPlayerEntityFeature.SHUFFLE_SET
 
         # This assumes there is at least one input that supports preset
-        supported_commands |= MediaPlayerEntityFeature.BROWSE_MEDIA
-        supported_commands |= MediaPlayerEntityFeature.PLAY_MEDIA
+        if self._has_subunit_that_supports_presets():
+            supported_commands |= MediaPlayerEntityFeature.BROWSE_MEDIA
+            supported_commands |= MediaPlayerEntityFeature.PLAY_MEDIA
 
         return supported_commands
+
+    def _has_subunit_that_supports_presets(self):
+        source_mapping = InputHelper.get_source_mapping(self._ynca)
+
+        for input in source_mapping:
+            if input.value not in self._hidden_inputs:
+                if subunit := InputHelper.get_subunit_for_input(self._ynca, input):
+                    if hasattr(
+                        subunit, "preset"
+                    ):
+                        return True
+                    # also covers fmpreset since on the same subunit
+                    if hasattr(
+                        subunit, "dabpreset"  
+                    ):
+                        return True
+        return False
 
     def turn_on(self):
         """Turn the media player on."""

--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -455,9 +455,7 @@ class YamahaYncaZone(MediaPlayerEntity):
         if subunit := self._get_input_subunit():
             if subunit is self._ynca.tun:
                 # AM/FM Tuner
-                preset_prefix = ""
-                if subunit.preset is not None:
-                    preset_prefix = f"{subunit.preset}: "
+                preset_prefix = f"{subunit.preset}: " if subunit.preset is not None else ""
                 if subunit.band is ynca.BandTun.AM:
                     return f"{preset_prefix}AM {subunit.amfreq} kHz"
                 if subunit.band is ynca.BandTun.FM:
@@ -469,10 +467,11 @@ class YamahaYncaZone(MediaPlayerEntity):
             if subunit is self._ynca.dab:
                 # DAB/FM Tuner
                 if subunit.band is ynca.BandDab.FM:
+                    preset_prefix = f"{subunit.fmpreset}: " if subunit.fmpreset is not None and subunit.fmpreset is not ynca.FmPreset.NO_PRESET else ""
                     return (
                         subunit.fmrdsprgservice
                         if subunit.fmrdsprgservice
-                        else f"FM {subunit.fmfreq:.2f} MHz"
+                        else f"{preset_prefix}FM {subunit.fmfreq:.2f} MHz"
                     )
                 if subunit.band is ynca.BandDab.DAB:
                     return subunit.dabservicelabel

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -326,8 +326,6 @@ async def test_mediaplayer_entity_supported_features(
     expected_supported_features = (
         MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
-        | MediaPlayerEntityFeature.BROWSE_MEDIA
-        | MediaPlayerEntityFeature.PLAY_MEDIA
     )
 
     # Nothing supported (still reports on/off)
@@ -360,9 +358,16 @@ async def test_mediaplayer_entity_supported_features(
     expected_supported_features |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
     assert mp_entity.supported_features == expected_supported_features
 
+    # Radio supports presets
+    mock_ynca.dab = create_autospec(ynca.subunits.dab.Dab)
+    mock_zone.inp = ynca.Input.TUNER
+    expected_supported_features |= MediaPlayerEntityFeature.BROWSE_MEDIA
+    expected_supported_features |= MediaPlayerEntityFeature.PLAY_MEDIA
+    assert mp_entity.supported_features == expected_supported_features
+
     # Sources with `playback` attribute support playback controls
 
-    # Radio sources only support play and stop
+    # Internet radio sources support play and stop
     mock_ynca.netradio = create_autospec(ynca.subunits.netradio.NetRadio)
     mock_zone.inp = ynca.Input.NETRADIO
     expected_supported_features |= MediaPlayerEntityFeature.PLAY

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -505,9 +505,15 @@ async def test_mediaplayer_mediainfo(mp_entity: YamahaYncaZone, mock_zone, mock_
     mock_ynca.dab.band = ynca.BandDab.FM
     mock_ynca.dab.fmfreq = 123.45
     mock_ynca.dab.fmrdsprgservice = None
+    mock_ynca.dab.fmpreset = None
     assert mp_entity.media_title is None
     assert mp_entity.media_channel == "FM 123.45 MHz"
     assert mp_entity.media_content_type is MediaType.CHANNEL
+
+    mock_ynca.dab.fmpreset = ynca.FmPreset.NO_PRESET
+    assert mp_entity.media_channel == "FM 123.45 MHz"
+    mock_ynca.dab.fmpreset = 22
+    assert mp_entity.media_channel == "22: FM 123.45 MHz"
 
     mock_ynca.dab.fmrdsprgservice = "FM RDS PRG SERVICE"
     assert mp_entity.media_title is None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for presets in Yamaha YNCA media players, including the ability to handle preset prefixes for various tuner types.
- **Bug Fixes**
	- Improved handling of media channel information for FM presets.
- **Tests**
	- Updated tests to reflect changes in supported features and media channel information handling for presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->