### PR TITLE
Remove preset prefix on frequencies

### DIFF
--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -469,30 +469,21 @@ class YamahaYncaZone(MediaPlayerEntity):
         if subunit := self._get_input_subunit():
             if subunit is self._ynca.tun:
                 # AM/FM Tuner
-                preset_prefix = (
-                    f"{subunit.preset}: " if subunit.preset is not None else ""
-                )
                 if subunit.band is ynca.BandTun.AM:
-                    return f"{preset_prefix}AM {subunit.amfreq} kHz"
+                    return f"AM {subunit.amfreq} kHz"
                 if subunit.band is ynca.BandTun.FM:
                     return (
                         subunit.rdsprgservice
                         if subunit.rdsprgservice
-                        else f"{preset_prefix}FM {subunit.fmfreq:.2f} MHz"
+                        else f"FM {subunit.fmfreq:.2f} MHz"
                     )
             if subunit is self._ynca.dab:
                 # DAB/FM Tuner
                 if subunit.band is ynca.BandDab.FM:
-                    preset_prefix = (
-                        f"{subunit.fmpreset}: "
-                        if subunit.fmpreset is not None
-                        and subunit.fmpreset is not ynca.FmPreset.NO_PRESET
-                        else ""
-                    )
                     return (
                         subunit.fmrdsprgservice
                         if subunit.fmrdsprgservice
-                        else f"{preset_prefix}FM {subunit.fmfreq:.2f} MHz"
+                        else f"FM {subunit.fmfreq:.2f} MHz"
                     )
                 if subunit.band is ynca.BandDab.DAB:
                     return subunit.dabservicelabel

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -481,8 +481,6 @@ async def test_mediaplayer_mediainfo(mp_entity: YamahaYncaZone, mock_zone, mock_
     assert mp_entity.media_title is None
     assert mp_entity.media_channel == "AM 1234 kHz"
     assert mp_entity.media_content_type is MediaType.CHANNEL
-    mock_ynca.tun.preset = 12  # Preset is prefixed when available
-    assert mp_entity.media_channel == "12: AM 1234 kHz"
 
     # FM can have name from RDS info or falls back to band and frequency
     mock_ynca.tun.preset = None
@@ -492,8 +490,6 @@ async def test_mediaplayer_mediainfo(mp_entity: YamahaYncaZone, mock_zone, mock_
     assert mp_entity.media_title is None
     assert mp_entity.media_channel == "FM 123.45 MHz"
     assert mp_entity.media_content_type is MediaType.CHANNEL
-    mock_ynca.tun.preset = 23  # Preset is prefixed when available
-    assert mp_entity.media_channel == "23: FM 123.45 MHz"
 
     mock_ynca.tun.rdsprgservice = "RDS PRG SERVICE"
     assert mp_entity.media_title is None
@@ -516,8 +512,6 @@ async def test_mediaplayer_mediainfo(mp_entity: YamahaYncaZone, mock_zone, mock_
 
     mock_ynca.dab.fmpreset = ynca.FmPreset.NO_PRESET
     assert mp_entity.media_channel == "FM 123.45 MHz"
-    mock_ynca.dab.fmpreset = 22
-    assert mp_entity.media_channel == "22: FM 123.45 MHz"
 
     mock_ynca.dab.fmrdsprgservice = "FM RDS PRG SERVICE"
     assert mp_entity.media_title is None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the handling of AM/FM and DAB/FM tuner channels in the media player component.
- **Tests**
	- Updated tests to reflect changes in media channel handling for AM and FM channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->