### PR TITLE
Add 1 second delay for tuner presets

### DIFF
--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any, List, Optional
 
 import voluptuous as vol  # type: ignore[import]
@@ -640,6 +641,12 @@ class YamahaYncaZone(MediaPlayerEntity):
         input = InputHelper.get_input_for_subunit(subunit)
         if self._zone.inp is not input:
             self._zone.inp = input
+
+            # Tuner input needs some time before it is possible to set the preset
+            # it gets ignored otherwise
+            # see https://github.com/mvdwetering/yamaha_ynca/issues/271
+            if input == ynca.Input.TUNER:
+                await asyncio.sleep(1.0)
 
         setattr(subunit, media_id_command, int(media_id_preset_id))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of setting presets for tuner input by introducing a delay, addressing a timing-related issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->