### PR TITLE
Also check if HDMOUT is supported. Next to HDMI2 available or not

### DIFF
--- a/custom_components/yamaha_ynca/select.py
+++ b/custom_components/yamaha_ynca/select.py
@@ -221,8 +221,10 @@ ENTITY_DESCRIPTIONS = [
         ],
         # HDMIOUT is used for receivers with multiple HDMI outputs and single HDMI output
         # This select handles multiple HDMI outputs, so check if HDMI2 exists to see if it is supported
-        supported_check=lambda _, zone_subunit: zone_subunit.lipsynchdmiout2offset
-        is not None,
+        supported_check=lambda _, zone_subunit: (
+            getattr(zone_subunit, "hdmiout", None) is not None
+            and zone_subunit.lipsynchdmiout2offset is not None
+        ),
     ),
     YncaSelectEntityDescription(  # type: ignore
         key="sleep",

--- a/custom_components/yamaha_ynca/switch.py
+++ b/custom_components/yamaha_ynca/switch.py
@@ -82,8 +82,10 @@ ZONE_ENTITY_DESCRIPTIONS = [
         off=ynca.HdmiOut.OFF,
         # HDMIOUT is used for receivers with multiple HDMI outputs and single HDMI output
         # This switch handles single HDMI output, so check if HDMI2 does NOT exist and assume there is only one HDMI output
-        supported_check=lambda _, zone_subunit: zone_subunit.lipsynchdmiout2offset
-        is None,
+        supported_check=lambda _, zone_subunit: (
+            getattr(zone_subunit, "hdmiout", None) is not None
+            and zone_subunit.lipsynchdmiout2offset is None
+        ),
     ),
 ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support check for HDMI output, improving reliability and error prevention in device compatibility.
- **Bug Fixes**
	- Improved logic for determining support, ensuring both `hdmiout` and `lipsynchdmiout2offset` attributes must be present and valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->