### PR TITLE
Fix default zoneb mediaplayer entityname

### DIFF
--- a/custom_components/yamaha_ynca/__init__.py
+++ b/custom_components/yamaha_ynca/__init__.py
@@ -94,7 +94,7 @@ def build_zoneb_devicename(receiver):
     devicename = f"{receiver.sys.modelname} ZoneB"
     if (
         receiver.main.zonebname
-        and receiver.main.zonebname.lower() != "ZoneB".lower
+        and receiver.main.zonebname.lower() != "ZoneB".lower()
     ):
         # Prefer user defined name over "MODEL ZONE" naming
         devicename = receiver.main.zonebname

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,7 @@ def mock_zone_main_with_zoneb(mock_zone_main):
     main_mock_with_zoneb.pwrb = ynca.PwrB.ON
     main_mock_with_zoneb.zonebavail = ynca.ZoneBAvail.READY
     main_mock_with_zoneb.zonebmute = ynca.ZoneBMute.OFF
+    main_mock_with_zoneb.zonebname = "ZoneB"
     main_mock_with_zoneb.zonebvol = -34.5
     return main_mock_with_zoneb
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected string comparison logic for ZoneB device name to ensure accurate functionality.
  
- **New Features**
	- Added `zonebname` attribute to the mock object for enhanced test clarity.
	- Introduced a new test function to verify correct entity ID assignments for media players.

- **Refactor**
	- Updated test cases for consistency in naming conventions related to zone entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->