### PR TITLE
Bump ynca to 5.17.0

### DIFF
--- a/custom_components/yamaha_ynca/manifest.json
+++ b/custom_components/yamaha_ynca/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/mvdwetering/yamaha_ynca/issues",
   "loggers": ["ynca"],
   "requirements": [
-    "ynca==5.17.0b0"
+    "ynca==5.17.0"
   ],
   "version": "0.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
-# This file is copied from Home Assistant and might be out of date
+# This file is copied from Home Assistant and will be out of date
 
 [tool.black]
-target-version = ["py39", "py310"]
+target-version = ["py312"]
 exclude = 'generated'
 
 [tool.isort]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Also update manifest.json!
-ynca==5.17.0b0
+ynca==5.17.0


### PR DESCRIPTION
Fixes missing Pure Direct switch in some receivers like RX-V1067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `ynca` dependency to a stable version (5.17.0) across multiple components.
- **Documentation**
	- Clarified comments in the configuration files regarding version updates.
- **Bug Fixes**
	- Transitioned from a beta version of `ynca` to a stable release, ensuring improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->