### PR TITLE
Modifications for receiver with optical inputs

### DIFF
--- a/custom_components/yamaha_ynca/config_flow.py
+++ b/custom_components/yamaha_ynca/config_flow.py
@@ -72,7 +72,7 @@ class YamahaYncaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     # When updating also update the one used in `setup_integration` for tests
     VERSION = 7
-    MINOR_VERSION = 5
+    MINOR_VERSION = 6
 
     reconfigure_entry: YamahaYncaConfigEntry | None = None
 

--- a/custom_components/yamaha_ynca/input_helpers.py
+++ b/custom_components/yamaha_ynca/input_helpers.py
@@ -54,13 +54,13 @@ input_mappings: List[Mapping] = [
     Mapping(ynca.Input.HDMI5, []),
     Mapping(ynca.Input.HDMI6, []),
     Mapping(ynca.Input.HDMI7, []),
+    Mapping(ynca.Input.MULTICH, []),
     Mapping(ynca.Input.OPTICAL1, []),
     Mapping(ynca.Input.OPTICAL2, []),
-    Mapping(ynca.Input.MULTICH, []),
     Mapping(ynca.Input.PHONO, []),
     Mapping(ynca.Input.TV, []),
-    Mapping(ynca.Input.VAUX, []),
     Mapping(ynca.Input.USB, []),
+    Mapping(ynca.Input.VAUX, []),
 ]
 
 

--- a/custom_components/yamaha_ynca/input_helpers.py
+++ b/custom_components/yamaha_ynca/input_helpers.py
@@ -54,6 +54,8 @@ input_mappings: List[Mapping] = [
     Mapping(ynca.Input.HDMI5, []),
     Mapping(ynca.Input.HDMI6, []),
     Mapping(ynca.Input.HDMI7, []),
+    Mapping(ynca.Input.OPTICAL1, []),
+    Mapping(ynca.Input.OPTICAL2, []),
     Mapping(ynca.Input.MULTICH, []),
     Mapping(ynca.Input.PHONO, []),
     Mapping(ynca.Input.TV, []),

--- a/custom_components/yamaha_ynca/manifest.json
+++ b/custom_components/yamaha_ynca/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/mvdwetering/yamaha_ynca/issues",
   "loggers": ["ynca"],
   "requirements": [
-    "ynca==5.17.0"
+    "ynca==5.17.1"
   ],
   "version": "0.0.0"
 }

--- a/custom_components/yamaha_ynca/migrations.py
+++ b/custom_components/yamaha_ynca/migrations.py
@@ -76,12 +76,11 @@ def migrate_v7_5_to_v7_6(hass: HomeAssistant, config_entry: ConfigEntry):
             options[zone_id]["hidden_inputs"] = options[zone_id].get(
                 "hidden_inputs", []
             )
-            options[zone_id]["hidden_inputs"].append("OPTICAL1").append("OPTICAL2")
+            options[zone_id]["hidden_inputs"].extend(["OPTICAL1", "OPTICAL2"])
 
     hass.config_entries.async_update_entry(
-        config_entry, options=options, minor_version=5
+        config_entry, options=options, minor_version=6
     )
-
 
 def migrate_v7_4_to_v7_5(hass: HomeAssistant, config_entry: ConfigEntry):
     options = dict(config_entry.options)  # Convert to dict to be able to use .get

--- a/custom_components/yamaha_ynca/migrations.py
+++ b/custom_components/yamaha_ynca/migrations.py
@@ -46,6 +46,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             migrate_v7_3_to_v7_4(hass, config_entry)
         if config_entry.minor_version == 4:
             migrate_v7_4_to_v7_5(hass, config_entry)
+        if config_entry.minor_version == 5:
+            migrate_v7_5_to_v7_6(hass, config_entry)
 
     # When adding new migrations do _not_ forget
     # to increase the VERSION of the YamahaYncaConfigFlow
@@ -60,6 +62,25 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     )
 
     return True
+
+def migrate_v7_5_to_v7_6(hass: HomeAssistant, config_entry: ConfigEntry):
+    options = dict(config_entry.options)  # Convert to dict to be able to use .get
+
+    # Hide new TV input for existing users
+    # Code is robust against unsupported inputs being listed in "hidden_input"s
+
+    # Upgrading from _really_ old version might not have zones key
+    if "zones" in config_entry.data:
+        for zone_id in config_entry.data["zones"]:
+            options[zone_id] = options.get(zone_id, {})
+            options[zone_id]["hidden_inputs"] = options[zone_id].get(
+                "hidden_inputs", []
+            )
+            options[zone_id]["hidden_inputs"].append("OPTICAL1").append("OPTICAL2")
+
+    hass.config_entries.async_update_entry(
+        config_entry, options=options, minor_version=5
+    )
 
 
 def migrate_v7_4_to_v7_5(hass: HomeAssistant, config_entry: ConfigEntry):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Also update manifest.json!
-ynca==5.17.0
+ynca==5.17.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,7 @@ def device_reg(hass: HomeAssistant) -> device_registry.DeviceRegistry:
 def create_mock_config_entry(modelname=None, zones=None, serial_url=None):
     return MockConfigEntry(
         version=7,
-        minor_version=5,
+        minor_version=6,
         domain=yamaha_ynca.DOMAIN,
         entry_id="entry_id",
         title=MODELNAME,

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -535,3 +535,30 @@ async def test_async_migration_entry_version_v7_4_to_v7_5(
     assert len(new_entry.options["ZONE2"]["hidden_inputs"]) == 2
     assert "TV" in new_entry.options["ZONE2"]["hidden_inputs"]
     assert "SOME INPUT" in new_entry.options["ZONE2"]["hidden_inputs"]
+
+async def test_async_migration_entry_version_v7_5_to_v7_6(
+    hass: HomeAssistant,
+):
+    config_entry = MockConfigEntry(
+        domain=yamaha_ynca.DOMAIN,
+        entry_id="entry_id",
+        title="ModelName",
+        data={"serial_url": "SerialUrl", "zones": ["ZONE2"], "modelname": "ModelName"},
+        options={"ZONE2": {"hidden_inputs": ["SOME INPUT"]}},
+        version=7,
+    )
+    config_entry.add_to_hass(hass)
+
+    # Migrate
+    yamaha_ynca.migrations.migrate_v7_5_to_v7_6(hass, config_entry)
+    await hass.async_block_till_done()
+
+    new_entry = hass.config_entries.async_get_entry(config_entry.entry_id)
+    assert new_entry is not None
+    assert new_entry.version == 7
+    assert new_entry.minor_version == 6
+    assert len(new_entry.options.keys()) == 1
+    assert len(new_entry.options["ZONE2"]["hidden_inputs"]) == 2
+    assert "OPTICAL1" in new_entry.options["ZONE2"]["hidden_inputs"]
+    assert "OPTICAL2" in new_entry.options["ZONE2"]["hidden_inputs"]
+    assert "SOME INPUT" in new_entry.options["ZONE2"]["hidden_inputs"]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -43,7 +43,7 @@ async def test_async_migration_entry(hass: HomeAssistant):
     new_entry = hass.config_entries.async_get_entry(old_entry.entry_id)
     assert new_entry is not None
     assert new_entry.version == 7
-    assert new_entry.minor_version == 5
+    assert new_entry.minor_version == 6
 
 
 async def test_async_migration_entry_version_v1_to_v2(hass: HomeAssistant):
@@ -558,7 +558,7 @@ async def test_async_migration_entry_version_v7_5_to_v7_6(
     assert new_entry.version == 7
     assert new_entry.minor_version == 6
     assert len(new_entry.options.keys()) == 1
-    assert len(new_entry.options["ZONE2"]["hidden_inputs"]) == 2
+    assert len(new_entry.options["ZONE2"]["hidden_inputs"]) == 3
     assert "OPTICAL1" in new_entry.options["ZONE2"]["hidden_inputs"]
     assert "OPTICAL2" in new_entry.options["ZONE2"]["hidden_inputs"]
     assert "SOME INPUT" in new_entry.options["ZONE2"]["hidden_inputs"]

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -66,6 +66,8 @@ ALL_INPUTS = [
     "HDMI6",
     "HDMI7",
     "MULTI CH",
+    "OPTICAL1",
+    "OPTICAL2",
     "PHONO",
     "TV",
     "USB",


### PR DESCRIPTION
Tested on a fresh installation with an R-N500. The corresponding pull request is also available for the internal python library. I have not executed the tests, as I modified the code directly on my HA installation with a restricted Python environment. However, I tried to mirror the changes of previous PRs (#294) that included new sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new input mappings for OPTICAL1 and OPTICAL2.
	- Updated configuration flow to support the new minor version.

- **Bug Fixes**
	- Improved migration logic to handle transitions between versions more effectively.

- **Documentation**
	- Updated requirements to reflect the latest dependency version.

- **Tests**
	- Added new tests for migration and configuration options, ensuring robustness of new features.
	- Adjusted existing tests to align with the updated migration logic and new inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->