### PR TITLE
Add switch for Direct mode (e.g. for RX-V473)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If your receiver works and is not in the list, please post a message in the [dis
   * Max volume
   * Sleep timer
   * Surround Decoder
-  * Pure Direct
+  * Direct / Pure Direct
   * Speaker bass/treble (default disabled)
   * Headphone bass/treble (default disabled)
 

--- a/custom_components/yamaha_ynca/manifest.json
+++ b/custom_components/yamaha_ynca/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/mvdwetering/yamaha_ynca/issues",
   "loggers": ["ynca"],
   "requirements": [
-    "ynca==5.17.1"
+    "ynca==5.18.0"
   ],
   "version": "0.0.0"
 }

--- a/custom_components/yamaha_ynca/switch.py
+++ b/custom_components/yamaha_ynca/switch.py
@@ -47,29 +47,22 @@ ZONE_ENTITY_DESCRIPTIONS = [
     # Suppress following mypy message, which seems to be not an issue as other values have defaults:
     # custom_components/yamaha_ynca/number.py:19: error: Missing positional arguments "entity_registry_enabled_default", "entity_registry_visible_default", "force_update", "icon", "has_entity_name", "unit_of_measurement", "max_value", "min_value", "step" in call to "NumberEntityDescription"  [call-arg]
     YncaSwitchEntityDescription(  # type: ignore
-        key="enhancer",
-        entity_category=EntityCategory.CONFIG,
-        on=ynca.Enhancer.ON,
-        off=ynca.Enhancer.OFF,
-    ),
-    YncaSwitchEntityDescription(  # type: ignore
         key="adaptivedrc",
         entity_category=EntityCategory.CONFIG,
         on=ynca.AdaptiveDrc.AUTO,
         off=ynca.AdaptiveDrc.OFF,
     ),
     YncaSwitchEntityDescription(  # type: ignore
-        key="threedcinema",
+        key="dirmode",
         entity_category=EntityCategory.CONFIG,
-        function_names=["3DCINEMA"],
-        on=ynca.ThreeDeeCinema.AUTO,
-        off=ynca.ThreeDeeCinema.OFF,
+        on=ynca.DirMode.ON,
+        off=ynca.DirMode.OFF,
     ),
     YncaSwitchEntityDescription(  # type: ignore
-        key="puredirmode",
+        key="enhancer",
         entity_category=EntityCategory.CONFIG,
-        on=ynca.PureDirMode.ON,
-        off=ynca.PureDirMode.OFF,
+        on=ynca.Enhancer.ON,
+        off=ynca.Enhancer.OFF,
     ),
     YncaSwitchEntityDescription(  # type: ignore
         key="hdmiout",
@@ -83,6 +76,12 @@ ZONE_ENTITY_DESCRIPTIONS = [
             subunit_supports_entitydescription_key(entity_description, zone_subunit)
             and zone_subunit.lipsynchdmiout2offset is None
         ),
+    ),
+    YncaSwitchEntityDescription(  # type: ignore
+        key="puredirmode",
+        entity_category=EntityCategory.CONFIG,
+        on=ynca.PureDirMode.ON,
+        off=ynca.PureDirMode.OFF,
     ),
     YncaSwitchEntityDescription(  # type: ignore
         key="speakera",
@@ -109,6 +108,13 @@ ZONE_ENTITY_DESCRIPTIONS = [
             subunit_supports_entitydescription_key(entity_description, zone_subunit)
             and getattr(zone_subunit, "zonebavail", None) is not ynca.ZoneBAvail.READY
         ),
+    ),
+    YncaSwitchEntityDescription(  # type: ignore
+        key="threedcinema",
+        entity_category=EntityCategory.CONFIG,
+        function_names=["3DCINEMA"],
+        on=ynca.ThreeDeeCinema.AUTO,
+        off=ynca.ThreeDeeCinema.OFF,
     ),
 ]
 

--- a/custom_components/yamaha_ynca/translations/en.json
+++ b/custom_components/yamaha_ynca/translations/en.json
@@ -133,8 +133,14 @@
       "adaptivedrc": {
         "name": "Adaptive DRC"
       },
+      "dirmode": {
+        "name": "Direct"
+      },
       "enhancer": {
         "name": "Compressed Music Enhancer"
+      },
+      "hdmiout": {
+        "name": "HDMI Out"
       },
       "hdmiout1": {
         "name": "HDMI Out 1"
@@ -153,9 +159,6 @@
       },
       "threedcinema": {
         "name": "CINEMA DSP 3D Mode"
-      },
-      "hdmiout": {
-        "name": "HDMI Out"
       }
     },
     "select": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Also update manifest.json!
-ynca==5.17.1
+ynca==5.18.0

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -38,12 +38,14 @@ async def test_async_setup_entry(
     mock_ynca.main = mock_zone_main
     mock_ynca.main.adaptivedrc = ynca.AdaptiveDrc.OFF
     mock_ynca.main.enhancer = ynca.Enhancer.OFF
-    mock_ynca.main.threedcinema = ynca.ThreeDeeCinema.AUTO
-    mock_ynca.main.puredirmode = ynca.PureDirMode.OFF
+    mock_ynca.main.dirmode = ynca.PureDirMode.ON
     mock_ynca.main.hdmiout = ynca.HdmiOut.OUT
     mock_ynca.main.lipsynchdmiout2offset = None
+    mock_ynca.main.puredirmode = ynca.PureDirMode.OFF
     mock_ynca.main.speakera = ynca.SpeakerA.OFF
     mock_ynca.main.speakerb = ynca.SpeakerB.ON
+    mock_ynca.main.threedcinema = ynca.ThreeDeeCinema.AUTO
+
     mock_ynca.sys.hdmiout1 = ynca.HdmiOutOnOff.OFF
     mock_ynca.sys.hdmiout2 = ynca.HdmiOutOnOff.ON
 
@@ -65,7 +67,7 @@ async def test_async_setup_entry(
 
     add_entities_mock.assert_called_once()
     entities = add_entities_mock.call_args.args[0]
-    assert len(entities) == 9
+    assert len(entities) == 10
 
 
 async def test_switch_entity_fields(mock_zone):

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -38,7 +38,7 @@ async def test_async_setup_entry(
     mock_ynca.main = mock_zone_main
     mock_ynca.main.adaptivedrc = ynca.AdaptiveDrc.OFF
     mock_ynca.main.enhancer = ynca.Enhancer.OFF
-    mock_ynca.main.dirmode = ynca.PureDirMode.ON
+    mock_ynca.main.dirmode = ynca.DirMode.ON
     mock_ynca.main.hdmiout = ynca.HdmiOut.OUT
     mock_ynca.main.lipsynchdmiout2offset = None
     mock_ynca.main.puredirmode = ynca.PureDirMode.OFF


### PR DESCRIPTION
Add switch for Direct mode. Direct is like Pure Direct, but less pure 🙂
Pure Direct seems to be an evolution of Direct and bypasses more signal processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new action `store_preset` for storing presets in the Yamaha integration.
	- Added new entities `dirmode` and `hdmiout` for enhanced control options.

- **Improvements**
	- Enhanced documentation for better clarity on integration features, including updated descriptions and examples.
	- Updated volume control explanations and expanded remote command details.
	- Restructured switch entities for better alignment with functionality.

- **Bug Fixes**
	- Resolved duplicate entry for `hdmiout` in translations.

- **Chores**
	- Updated dependency version for `ynca` to ensure compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->