### PR TITLE
Workaround for missing dirmode updates

### DIFF
--- a/custom_components/yamaha_ynca/switch.py
+++ b/custom_components/yamaha_ynca/switch.py
@@ -18,7 +18,7 @@ from .helpers import YamahaYncaSettingEntity, subunit_supports_entitydescription
 
 if TYPE_CHECKING:  # pragma: no cover
     from ynca.subunits.zone import ZoneBase
-
+    from ynca.subunit import SubunitBase
 
 @dataclass(frozen=True, kw_only=True)
 class YncaSwitchEntityDescription(SwitchEntityDescription):
@@ -187,6 +187,16 @@ class YamahaYncaSwitch(YamahaYncaSettingEntity, SwitchEntity):
 
     entity_description: YncaSwitchEntityDescription
 
+    def __init__(
+        self,
+        receiver_unique_id: str,
+        subunit: SubunitBase,
+        description: YncaSwitchEntityDescription,
+        associated_zone: ZoneBase | None = None,
+    ):
+        super().__init__(receiver_unique_id, subunit, description, associated_zone)
+        self._dirmode_get_sent = datetime.fromtimestamp(0)
+
     @property
     def is_on(self) -> bool | None:
         """Return True if entity is on."""
@@ -212,10 +222,10 @@ class YamahaYncaSwitch(YamahaYncaSettingEntity, SwitchEntity):
         if self.entity_description.key == "dirmode" and function == "STRAIGHT":
 
             # But because STRAIGHT also gets reported on GET we need to avoid an infinite loop
-            if hasattr(self, "_dirmode_get_sent") and (datetime.now() - self._dirmode_get_sent < timedelta(seconds=0.5)):
+            if self._dirmode_get_sent and (datetime.now() - self._dirmode_get_sent < timedelta(seconds=0.5)):
                 return
 
             # There is no API in `ynca` to explicitly do a GET
             # So use internal knowledge for now and ignore the typing issue
             self._associated_zone._connection.get(self._associated_zone.id, "DIRMODE") # type: ignore[union-attr]
-            self._dirmode_get_sent:datetime = datetime.now()
+            self._dirmode_get_sent = datetime.now()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,7 @@ def create_mock_zone(spec=None):
 
     # Disable all features (is there an easier way with less maintenance?)
     zone.adaptivedrc = None
+    zone.dirmode = None
     zone.enhancer = None
     zone.hdmiout = None
     zone.hpbass = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for handling updates in the Yamaha YNCA switch, improving the management of the `DIRMODE` state.
	- Added a new entity description for the "dirmode" switch in the integration tests.

- **Bug Fixes**
	- Enhanced error handling and control flow to prevent unnecessary GET requests related to the `DIRMODE` state.

- **Tests**
	- Expanded test coverage with a new asynchronous test for the `YamahaYncaSwitch` related to the "dirmode" feature.
	- Updated the mock zone to include a `dirmode` attribute for improved testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->