### PR TITLE
Update README.md, add RX-S601D

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If your receiver works and is not in the list, please post a message in the [dis
 || RX-V3067, RX-V3071, RX-V3075, RX-V3077 |
 | HTR | HTR-4065, HTR-4066, HTR-4071, HTR-4072, HTR-6064 |
 | TSR | TSR-700, TSR-7850 |
-| Other | CX-A5000, R-N500, RX-S600D |
+| Other | CX-A5000, R-N500, RX-S600D, RX-S601D |
 
 
 ## Features


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md to include the Yamaha model RX-S601D in the list of supported devices for Home Assistant integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->