### PR TITLE
Use new reconfigure helpers

### DIFF
--- a/custom_components/yamaha_ynca/config_flow.py
+++ b/custom_components/yamaha_ynca/config_flow.py
@@ -113,13 +113,8 @@ class YamahaYncaConfigFlow(ConfigFlow, domain=DOMAIN):
 
             if self.source == SOURCE_RECONFIGURE :
                 reconfigure_entry = self._get_reconfigure_entry()
-                self.hass.config_entries.async_update_entry(
-                    reconfigure_entry, data=data
-                )
-                await self.hass.config_entries.async_reload(
-                    reconfigure_entry.entry_id
-                )
-                return self.async_abort(reason="reconfigure_successful")
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry, data_updates=data, reload_even_if_entry_is_unchanged=False)
 
             return self.async_create_entry(title=check_result.modelname, data=data)
 


### PR DESCRIPTION
Use new helpers as mentioned in https://developers.home-assistant.io/blog/2024/10/21/reauth-reconfigure-helpers/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Yamaha integration reconfiguration flow to provide a smoother experience when updating connection settings, including improved handling of serial configurations. These improvements ensure that when reconfiguring the integration, users encounter a more reliable and accurate update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->