### PR TITLE
Derive from OptionsFlow iso OptionsFlowWithConfigEntry

### DIFF
--- a/custom_components/yamaha_ynca/config_flow.py
+++ b/custom_components/yamaha_ynca/config_flow.py
@@ -78,7 +78,7 @@ class YamahaYncaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(config_entry) -> OptionsFlowHandler:
         return OptionsFlowHandler(config_entry)
 
     async def async_step_user(

--- a/custom_components/yamaha_ynca/options_flow.py
+++ b/custom_components/yamaha_ynca/options_flow.py
@@ -1,6 +1,7 @@
 """Options flow for Yamaha (YNCA) integration."""
 
 from __future__ import annotations
+from copy import deepcopy
 from typing import Any
 
 import voluptuous as vol  # type: ignore
@@ -9,6 +10,7 @@ import ynca
 from homeassistant import config_entries
 import homeassistant.helpers.config_validation as cv
 
+from . import YamahaYncaConfigEntry
 from .const import (
     CONF_HIDDEN_INPUTS,
     CONF_HIDDEN_SOUND_MODES,
@@ -64,7 +66,10 @@ def get_next_step_id(flow: OptionsFlowHandler, current_step: str) -> str:
     return next_step
 
 
-class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
+class OptionsFlowHandler(config_entries.OptionsFlow):
+
+    def __init__(self, config_entry: YamahaYncaConfigEntry) -> None:
+        self.options = deepcopy(dict(config_entry.options))
 
     async def do_next_step(self, current_step_id: str):
         next_step_id = get_next_step_id(self, current_step_id)


### PR DESCRIPTION
Use new options flow properties as described in the blog https://developers.home-assistant.io/blog/2024/11/12/options-flow/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the configuration options experience for improved clarity and consistency when adjusting integration settings.  
  - Enhanced the initialization process to ensure user configurations are managed more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->