### PR TITLE
Update README.md, clarify presets don't work on all inputs for all mo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ cards:
 
 ## Presets
 
-Presets can be activated and stored with the integration for several inputsources. The most obvious input that support presets is the radio inputs like AM/FM or DAB tuner. Inputs that support presets are: Napster, Netradio, Pandora, PC, Rhapsody, Sirius, SiriusIR, Tuner and USB. 
+Presets can be activated and stored with the integration for some inputsources. The AM/FM or DAB radio input seems to work for all models. Other inputs only work on some models, probably older ones from before 2012. These input are: Napster, Netradio, Pandora, PC, Rhapsody, Sirius, SiriusIR and USB. 
 
 Presets can be selected in the mediabrowser of the mediaplayer or in automations with the `media_player.play_media` action. When selecting a preset, the receiver will turn on and switch input if needed.
 
@@ -604,7 +604,7 @@ target:
 
 ### Media content format
 
-In some cases it is not possible to select presets from the UI and it is needed to manually provide the `media_content_id` and `media_content_type`.
+In some cases it is not possible to browse for presets in the UI and it is needed to manually provide the `media_content_id` and `media_content_type`.
 
 The `media_content_type` is always "music". The `media_content_id` format is listed in the table below. Replace the "1" at the end with the preset number you need.
 


### PR DESCRIPTION
…dels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Refined descriptions for preset activation and storage, clarifying that presets are available for some input sources.
	- Specified model compatibility, highlighting that AM/FM and DAB inputs work universally, while others are limited to older models.
	- Updated UI language to indicate browsing for presets rather than selecting them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->