### PR TITLE
Add Surround:AI switch

### DIFF
--- a/custom_components/yamaha_ynca/switch.py
+++ b/custom_components/yamaha_ynca/switch.py
@@ -115,6 +115,13 @@ ZONE_ENTITY_DESCRIPTIONS = [
         ),
     ),
     YncaSwitchEntityDescription(  # type: ignore
+        key="surroundai",
+        icon="mdi:creation",
+        entity_category=EntityCategory.CONFIG,
+        on=ynca.SurroundAI.ON,
+        off=ynca.SurroundAI.OFF,
+    ),
+    YncaSwitchEntityDescription(  # type: ignore
         key="threedcinema",
         entity_category=EntityCategory.CONFIG,
         function_names=["3DCINEMA"],

--- a/custom_components/yamaha_ynca/translations/en.json
+++ b/custom_components/yamaha_ynca/translations/en.json
@@ -157,6 +157,9 @@
       "speakerb": {
         "name": "Zone B speakers"
       },
+      "surroundai": {
+        "name": "Surround:AI"
+      },
       "threedcinema": {
         "name": "CINEMA DSP 3D Mode"
       }

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -51,6 +51,7 @@ async def test_async_setup_entry(
     mock_ynca.main.puredirmode = ynca.PureDirMode.OFF
     mock_ynca.main.speakera = ynca.SpeakerA.OFF
     mock_ynca.main.speakerb = ynca.SpeakerB.ON
+    mock_ynca.main.surroundai = ynca.SurroundAI.OFF
     mock_ynca.main.threedcinema = ynca.ThreeDeeCinema.AUTO
 
     mock_ynca.sys.hdmiout1 = ynca.HdmiOutOnOff.OFF
@@ -74,7 +75,7 @@ async def test_async_setup_entry(
 
     add_entities_mock.assert_called_once()
     entities = add_entities_mock.call_args.args[0]
-    assert len(entities) == 10
+    assert len(entities) == 11
 
 
 async def test_switch_entity_fields(mock_zone):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Surround:AI control option to enhance your Yamaha integration, providing additional functionality for managing surround sound settings.
  - Updated the user interface translations to include the "Surround:AI" label.

- **Tests**
  - Revised test configurations to account for the newly added Surround:AI control option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->