### PR TITLE
Avoid exposing empty media metadata

### DIFF
--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -514,22 +514,25 @@ class YamahaYncaZone(MediaPlayerEntity):
             if track := getattr(subunit, "track", None):
                 return track
             if subunit is self._ynca.dab and subunit.band is ynca.BandDab.DAB:
-                if subunit.dabdlslabel:
-                    return subunit.dabdlslabel
+                return subunit.dabdlslabel or None
         return None
 
     @property
     def media_artist(self) -> str | None:
         """Artist of current playing media, music track only."""
-        if subunit := self._get_input_subunit():
-            return getattr(subunit, "artist", None)
+        if (subunit := self._get_input_subunit()) and (
+            artist := getattr(subunit, "artist", None)
+        ):
+            return artist
         return None
 
     @property
     def media_album_name(self) -> str | None:
         """Album name of current playing media, music track only."""
-        if subunit := self._get_input_subunit():
-            return getattr(subunit, "album", None)
+        if (subunit := self._get_input_subunit()) and (
+            album := getattr(subunit, "album", None)
+        ):
+            return album
         return None
 
     @property
@@ -555,7 +558,7 @@ class YamahaYncaZone(MediaPlayerEntity):
                         else f"FM {subunit.fmfreq:.2f} MHz"
                     )
                 if subunit.band is ynca.BandDab.DAB:
-                    return subunit.dabservicelabel
+                    return subunit.dabservicelabel or None
 
             # Netradio
             if station := getattr(subunit, "station", None):

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -547,6 +547,15 @@ async def test_mediaplayer_mediainfo(mp_entity: YamahaYncaZone, mock_zone, mock_
     mock_zone.inp = ynca.Input.USB
     mock_ynca.usb = create_autospec(ynca.subunits.usb.Usb)
 
+    # Empty metadata is not exposed
+    mock_ynca.usb.album = ""
+    mock_ynca.usb.artist = ""
+    mock_ynca.usb.song = ""
+    assert mp_entity.media_album_name is None
+    assert mp_entity.media_artist is None
+    assert mp_entity.media_title is None
+
+    # Available metadata is exposed
     mock_ynca.usb.album = "AlbumName"
     mock_ynca.usb.artist = "ArtistName"
     mock_ynca.usb.song = "Song title"
@@ -569,6 +578,12 @@ async def test_mediaplayer_mediainfo(mp_entity: YamahaYncaZone, mock_zone, mock_
     # Netradio is a "channel" which name is exposed by the "station" attribute
     mock_zone.inp = ynca.Input.NETRADIO
     mock_ynca.netradio = create_autospec(ynca.subunits.netradio.NetRadio)
+
+    # Empty metadata is not exposed
+    mock_ynca.netradio.station = ""
+    assert mp_entity.media_channel is None
+
+    # Available metadata is exposed
     mock_ynca.netradio.station = "StationName"
     mock_ynca.netradio.song = "SongName"
     mock_ynca.netradio.album = "AlbumName"


### PR DESCRIPTION
Ensures that empty metadata fields (album, artist, title, channel) are not exposed, preventing the display of empty strings in the media player interface.

Also adds a null check for dabservicelabel/dabdlslabel to prevent returning empty strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the media player’s handling of media details so that missing details are now addressed uniformly for a clearer display.
- **Tests**
  - Expanded test coverage to ensure that incomplete or empty media metadata is managed reliably, improving overall consistency in media information presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->