### PR TITLE
Use asyncio sleep

### DIFF
--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import time
+import asyncio
 from unittest.mock import ANY, Mock, call, patch
 
 from homeassistant.helpers.entity import EntityCategory
@@ -193,7 +193,7 @@ async def test_dirmode(hass, mock_ynca, mock_zone_main):
     mock_zone_main._connection.get.assert_not_called()
 
     # But after the cooldown expires it requests again
-    time.sleep(0.51)
+    await asyncio.sleep(0.51)
     callback("STRAIGHT", None)
     entity.schedule_update_ha_state.assert_not_called()
     mock_zone_main._connection.get.assert_called_once_with("MAIN", "DIRMODE")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cooldown-related test to use non-blocking asynchronous waiting, improving test stability and better aligning with event-driven execution.
  * Reduces flakiness and potential delays during test runs, leading to faster, more reliable CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->