### PR TITLE
Bump ynca to v5.23.0

### DIFF
--- a/custom_components/yamaha_ynca/manifest.json
+++ b/custom_components/yamaha_ynca/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/mvdwetering/yamaha_ynca/issues",
   "loggers": ["ynca"],
   "requirements": [
-    "ynca==5.22.0"
+    "ynca==5.23.0"
   ],
   "version": "0.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ keywords = [
 requires-python = ">=3.13"
 
 # Also update ynca version in manifest.json
-dependencies = ["ynca==5.22.0"]
+dependencies = ["ynca==5.23.0"]
 
 [project.urls]
 Documentation = "https://github.com/mvdwetering/yamaha_ynca"


### PR DESCRIPTION
Adds Main Zone Sync input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Yamaha YNCA integration’s external dependency to version 5.23.0 to align with upstream and incorporate the latest fixes and improvements.
  * Synchronized project dependency specifications to ensure consistent installs and builds across environments.
  * No user-facing behavior changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->