### PR TITLE
Add Main zone sync to input list

### DIFF
--- a/custom_components/yamaha_ynca/input_helpers.py
+++ b/custom_components/yamaha_ynca/input_helpers.py
@@ -54,6 +54,9 @@ input_mappings: list[Mapping] = [
     Mapping(ynca.Input.HDMI5, []),
     Mapping(ynca.Input.HDMI6, []),
     Mapping(ynca.Input.HDMI7, []),
+    Mapping(
+        ynca.Input.MAIN_ZONE_SYNC, []
+    ),  # Not an external input, but also not a subunit
     Mapping(ynca.Input.MULTICH, []),
     Mapping(ynca.Input.OPTICAL1, []),
     Mapping(ynca.Input.OPTICAL2, []),
@@ -135,7 +138,8 @@ class InputHelper:
                 source_mapping[mapping.ynca_input] = name
                 continue
 
-        # Some receivers don't expose external inputs as renameable so just add them all
+        # Some receivers don't expose external inputs as renameable (no support for INPNAME)
+        # so just add all non-subunit related inputs.
         if len(source_mapping) == 0:
             for mapping in input_mappings:
                 if not mapping.subunit_attribute_names:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the “Main Zone Sync” input in the Yamaha YNCA integration, so compatible receivers can recognize and select this source.
  * The input now appears in source lists and state reporting where supported, improving accuracy and consistency.
  * No configuration changes are required; the new input will surface automatically on devices that provide it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->