### PR TITLE
Fix main zone sync not showing on all receivers

### DIFF
--- a/custom_components/yamaha_ynca/input_helpers.py
+++ b/custom_components/yamaha_ynca/input_helpers.py
@@ -145,6 +145,10 @@ class InputHelper:
                 if not mapping.subunit_attribute_names:
                     source_mapping[mapping.ynca_input] = mapping.ynca_input.value
 
+        # Manually add Main Zone Sync because it can not be autodetected
+        if ynca.Input.MAIN_ZONE_SYNC not in source_mapping:
+            source_mapping[ynca.Input.MAIN_ZONE_SYNC] = ynca.Input.MAIN_ZONE_SYNC.value
+
         # Add sources from subunits
         for mapping in input_mappings:
             if mapping.ynca_input not in source_mapping:

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -52,11 +52,14 @@ def test_sourcemapping_inpname_some_set(mock_ynca):
 
     mapping = InputHelper.get_source_mapping(mock_ynca)
 
-    for input in ynca.Input:
-        if input is ynca.Input.HDMI4:
-            assert mapping[input] == "_INPNAMEHDMI4_"
+    for input_ in ynca.Input:
+        if input_ is ynca.Input.HDMI4:
+            assert mapping[input_] == "_INPNAMEHDMI4_"
+        elif input_ is ynca.Input.MAIN_ZONE_SYNC:
+            # Main Zone Sync should always be present
+            assert mapping[input_] == ynca.Input.MAIN_ZONE_SYNC.value
         else:
-            assert input not in mapping.keys()
+            assert input_ not in mapping
 
 
 def test_sourcemapping_inpnames_not_set(mock_ynca):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the MAIN_ZONE_SYNC input source is consistently included in the input source list, improving reliability of source selection across supported receivers, even when autodetection fails.

* **Tests**
  * Updated tests to cover the guaranteed presence of MAIN_ZONE_SYNC and improved variable naming for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->