### PR TITLE
Remove device option from target selector

### DIFF
--- a/custom_components/yamaha_ynca/services.yaml
+++ b/custom_components/yamaha_ynca/services.yaml
@@ -2,8 +2,6 @@
 
 send_raw_ynca:
   target:
-    device:
-      integration: yamaha_ynca
     entity:
       integration: yamaha_ynca
       domain: media_player


### PR DESCRIPTION
HA is removing support in 2025.11, see https://developers.home-assistant.io/blog/2025/10/14/device-filter-removed-from-target-selector/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated send_raw_ynca service to exclusively support entity-level targeting for media player devices; device-level targeting has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->