### PR TITLE
Update README, add CX–A5200

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If your receiver works but is not in the list, please post a message in the [dis
 | | RX-V | RX-V585, RX-V685, RX-V1085 |
 | | HTR | HTR-4072 |
 | | TSR | TSR-7850 |
-| | Other | CX–A5200 |
+| | Other | CX-A5200 |
 | 2020 | AVENTAGE | RX-A2A, RX-A4A, RX-A6A |
 | | RX-V | RX-V4A, RX-V6A |
 | | TSR | TSR-700 |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the "Working models" list to include CX-A5200 under the 2018 AVENTAGE/Other category.
  * Note: This is a documentation-only change; there are no functional or behavioral changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->