### PR TITLE
Remove deprecated hass argument from service helper

### DIFF
--- a/custom_components/yamaha_ynca/services.py
+++ b/custom_components/yamaha_ynca/services.py
@@ -18,7 +18,7 @@ SERVICE_STORE_PRESET = "store_preset"
 
 
 async def async_handle_send_raw_ynca(hass: HomeAssistant, call: ServiceCall) -> None:
-    for config_entry_id in await async_extract_config_entry_ids(hass, call):  # type: ignore[arg-type]
+    for config_entry_id in await async_extract_config_entry_ids(call):
         # Check if configentry is ours, could be others when targeting areas for example
         if (
             (config_entry := hass.config_entries.async_get_entry(config_entry_id))


### PR DESCRIPTION
For more context see: https://developers.home-assistant.io/blog/2025/09/22/deprecate-hass-argument-service-helpers/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to service configuration handling with no user-visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->