### PR TITLE
Pin pycares to avoid breaking change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ dev = [
   "pytest-homeassistant-custom-component==0.13.285",
   "awesomeversion>=24.0.0",
   "homeassistant-stubs==2025.10.0",
+
+  # Pin pycares to avoid aiodns incompatibility with pycares 5.0.0
+  # See: https://github.com/aio-libs/aiodns/issues/214
+  "pycares<5.0.0",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
This integration depends on HA 2025.10 which in turn depends on aiodns which in turn depends on pycares.

The pycares dependency in aiodns is "> some number". Now pycares got updated to version 5 and had in incompatible change causing issues when running this integrations tests with HA.

```
AttributeError: module 'pycares' has no attribute 'ares_query_a_result'
```

I don't want to bump the min HA version right now, so pin pycares to a version <5 and it should make pip resolve to the older version.

This should not cause issues for normal users because the intergration is not installed as a package when used in Home Assistant, but just the sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development dependency constraint to ensure compatibility and prevent conflicts in the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->