### PR TITLE
Add Sound Program Remote Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ The remote entity supports the following commands. Note that this command list d
 > av1, av2, av3, av4, av5, av6, av7,
 > audio1, audio2, audio3, audio4, audio5,
 > phono,
-> sp_up, sp_down, sp_straight, sp_movie, sp_music, sp_classical, sp_live_club, sp_entertainment,
-> sp_surround_decode, sp_stereo, sp_pure_direct, sp_enhancer
+> program+, program-, straight, movie, music, classical, live_club, entertainment,
+> surround_decode, stereo, pure_direct, enhancer
 
 More remote control IR codes exist, but for now the commands included are the ones that are not available on the other entities or that are potentially useful in other ways. E.g. sending `scene_1` can be used as a workaround for unsupported scene command on some receivers and commands like `play` are forwarded over HDMI-CEC so it allows you to control devices that do not have an API otherwise. HDMI, AV and Audio commands can be used to switch inputs when the receiver is Off (which cannot be done with the `media_player` entity). More commands can be added later if more use cases are discovered.
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ The remote entity supports the following commands. Note that this command list d
 > hdmi1, hdmi2, hdmi3, hdmi4, hdmi5, hdmi6, hdmi7,
 > av1, av2, av3, av4, av5, av6, av7,
 > audio1, audio2, audio3, audio4, audio5,
-> phono
+> phono,
+> sp_up, sp_down, sp_straight, sp_movie, sp_music, sp_classical, sp_live_club, sp_entertainment,
+> sp_surround_decode, sp_stereo, sp_pure_direct, sp_enhancer
 
 More remote control IR codes exist, but for now the commands included are the ones that are not available on the other entities or that are potentially useful in other ways. E.g. sending `scene_1` can be used as a workaround for unsupported scene command on some receivers and commands like `play` are forwarded over HDMI-CEC so it allows you to control devices that do not have an API otherwise. HDMI, AV and Audio commands can be used to switch inputs when the receiver is Off (which cannot be done with the `media_player` entity). More commands can be added later if more use cases are discovered.
 

--- a/custom_components/yamaha_ynca/remote.py
+++ b/custom_components/yamaha_ynca/remote.py
@@ -104,18 +104,18 @@ av6, 7A-621D
 av7, 7A-7609
 phono, 7A-14
 
-sp_up, 7A85-58A7
-sp_down, 7A85-59A6
-sp_straight, 7A85-56A9
-sp_movie, 7A85-8877
-sp_music, 7A85-8976
-sp_classical, 7A85-8A75
-sp_live_club, 7A85-8B74
-sp_entertainment, 7A85-8C73
-sp_surround_decode, 7A85-8D72
-sp_stereo, 7A85-8F70
-sp_pure_direct, 7A85-DD22
-sp_enhancer, 7A85-946B
+program+, 7A85-58A7
+program-, 7A85-59A6
+straight, 7A85-56A9
+movie, 7A85-8877
+music, 7A85-8976
+classical, 7A85-8A75
+live_club, 7A85-8B74
+entertainment, 7A85-8C73
+surround_decode, 7A85-8D72
+stereo, 7A85-8F70
+pure_direct, 7A85-DD22
+enhancer, 7A85-946B
 
 """
 

--- a/custom_components/yamaha_ynca/remote.py
+++ b/custom_components/yamaha_ynca/remote.py
@@ -104,6 +104,19 @@ av6, 7A-621D
 av7, 7A-7609
 phono, 7A-14
 
+sp_up, 7A85-58A7
+sp_down, 7A85-59A6
+sp_straight, 7A85-56A9
+sp_movie, 7A85-8877
+sp_music, 7A85-8976
+sp_classical, 7A85-8A75
+sp_live_club, 7A85-8B74
+sp_entertainment, 7A85-8C73
+sp_surround_decode, 7A85-8D72
+sp_stereo, 7A85-8F70
+sp_pure_direct, 7A85-DD22
+sp_enhancer, 7A85-946B
+
 """
 
 


### PR DESCRIPTION
This adds remote codes to control the sound programs on the receiver. Codes were sourced from https://www.avsforum.com/attachments/9348 and tested on my RX-A1030 through ynca directly and through this integration.

My motivation for this is that as of the current beta firmware of the Unfolded Circle Remote 3, the Home Assistant integration does not support select entities, which is how the surround decoder is exposed. It looks like this will be changing in the somewhat [near future](https://github.com/unfoldedcircle/integration-home-assistant/pull/83), so no worries if this change is rejected due to the functionality being exposed by other means.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for 12 additional remote commands (program+, program-, straight, movie, music, classical, live_club, entertainment, surround_decode, stereo, pure_direct, enhancer), expanding surround modes, playback presets, and audio enhancements.

* **Documentation**
  * Updated user-facing documentation to list and describe the newly supported remote commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->