### PR TITLE
Use placeholder for URL in translations

### DIFF
--- a/custom_components/yamaha_ynca/config_flow.py
+++ b/custom_components/yamaha_ynca/config_flow.py
@@ -30,6 +30,9 @@ from .options_flow import OptionsFlowHandler
 STEP_ID_SERIAL = "serial"
 STEP_ID_NETWORK = "network"
 STEP_ID_ADVANCED = "advanced"
+PYSERIAL_URL_HANDLERS_LINK = (
+    "https://pyserial.readthedocs.io/en/latest/url_handlers.html"
+)
 
 
 def get_serial_url_schema(user_input: dict[str, Any]) -> vol.Schema:
@@ -129,6 +132,11 @@ class YamahaYncaConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id=step_id,
             data_schema=data_schema,
             errors=errors,
+            description_placeholders=(
+                {"pyserial_url_handlers_link": PYSERIAL_URL_HANDLERS_LINK}
+                if step_id == STEP_ID_ADVANCED
+                else None
+            ),
         )
 
     async def async_step_serial(
@@ -194,6 +202,9 @@ class YamahaYncaConfigFlow(ConfigFlow, domain=DOMAIN):
                     if self.source == SOURCE_RECONFIGURE
                     else {}
                 ),
+                description_placeholders={
+                    "pyserial_url_handlers_link": PYSERIAL_URL_HANDLERS_LINK
+                },
             )
 
         return await self.async_try_connect(

--- a/custom_components/yamaha_ynca/translations/en.json
+++ b/custom_components/yamaha_ynca/translations/en.json
@@ -25,7 +25,7 @@
       },
       "advanced": {
         "title": "PySerial URL handler (advanced)",
-        "description": "Provide any [URL handler as supported by PySerial](https://pyserial.readthedocs.io/en/latest/url_handlers.html).\n\nThis can come in handy when addressing USB adapters by serial with `hwgrep://` or use `rfc2217://hostname_or_ip` to connect through an rfc2217 compatible server.",
+        "description": "Provide any [URL handler as supported by PySerial]({pyserial_url_handlers_link}).\n\nThis can come in handy when addressing USB adapters by serial with `hwgrep://` or use `rfc2217://hostname_or_ip` to connect through an rfc2217 compatible server.",
         "data": {
           "serial_url": "URL handler"
         }


### PR DESCRIPTION
## Summary
- replace hardcoded PySerial URL in translations/en.json with a placeholder
- provide the placeholder value from config_flow.py
- ensure placeholder is set both for initial advanced step form and re-show on errors

## Why
This fixes hassfest failures which disallows links in translations now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the advanced configuration step with a dynamic PySerial URL handlers documentation link, providing users with direct access to required setup information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->