### PR TITLE
Add current selected preset as extra_state_attribute on the media_player entity

### DIFF
--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -251,7 +251,7 @@ class YamahaYncaZone(MediaPlayerEntity):
         ):
             extra["preset"] = preset
 
-        return extra
+        return extra or None
 
     @property
     def volume_level(self) -> float | None:

--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -238,18 +238,25 @@ class YamahaYncaZone(MediaPlayerEntity):
         extra = {}
 
         # Add preset attribute
-        if (input_subunit := self._get_input_subunit()) and (
-            (preset := getattr(input_subunit, "preset", None))
-            or (
-                (preset := getattr(input_subunit, "dabpreset", None))
-                and preset is not ynca.DabPreset.NO_PRESET
-            )
-            or (
-                (preset := getattr(input_subunit, "fmpreset", None))
-                and preset is not ynca.FmPreset.NO_PRESET
-            )
-        ):
-            extra["preset"] = preset
+        if input_subunit := self._get_input_subunit():
+            if isinstance(input_subunit, ynca.Tun):
+                if (
+                    input_subunit.searchmode is ynca.TunSearchMode.PRESET
+                    and input_subunit.preset is not ynca.Preset.NO_PRESET
+                ):
+                    extra["preset"] = input_subunit.preset
+            elif isinstance(input_subunit, ynca.Dab):
+                if (
+                    input_subunit.band is ynca.BandDab.FM
+                    and input_subunit.fmsearchmode is ynca.DabFmSearchMode.PRESET
+                    and input_subunit.fmpreset is not ynca.FmPreset.NO_PRESET
+                ):
+                    extra["preset"] = input_subunit.fmpreset
+                elif (
+                    input_subunit.band is ynca.BandDab.DAB
+                    and input_subunit.dabpreset is not ynca.DabPreset.NO_PRESET
+                ):
+                    extra["preset"] = input_subunit.dabpreset
 
         return extra or None
 

--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -40,7 +40,7 @@ from .helpers import extract_protocol_version, scale
 from .input_helpers import InputHelper
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Generator
+    from collections.abc import Generator, Mapping
 
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -231,6 +231,27 @@ class YamahaYncaZone(MediaPlayerEntity):
                 return MediaPlayerState.IDLE
 
         return MediaPlayerState.ON
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return the extra attributes."""
+        extra = {}
+
+        # Add preset attribute
+        if (input_subunit := self._get_input_subunit()) and (
+            (preset := getattr(input_subunit, "preset", None))
+            or (
+                (preset := getattr(input_subunit, "dabpreset", None))
+                and preset is not ynca.DabPreset.NO_PRESET
+            )
+            or (
+                (preset := getattr(input_subunit, "fmpreset", None))
+                and preset is not ynca.FmPreset.NO_PRESET
+            )
+        ):
+            extra["preset"] = preset
+
+        return extra
 
     @property
     def volume_level(self) -> float | None:

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -761,7 +761,7 @@ async def test_mediaplayer_mediainfo_terrestrial_radio_inputs(
     assert mp_entity.media_content_type is MediaType.CHANNEL
 
 
-async def test_mediaplayer_extra_attributes_preset(
+async def test_mediaplayer_extra_attributes_tun_preset(
     mp_entity: YamahaYncaZone, mock_zone: Mock, mock_ynca: Mock
 ) -> None:
 
@@ -770,38 +770,54 @@ async def test_mediaplayer_extra_attributes_preset(
     mock_ynca.tun = create_autospec(ynca.subunits.tun.Tun)
     mock_ynca.tun.band = ynca.BandTun.AM
     mock_ynca.tun.amfreq = 1234
+    mock_ynca.tun.searchmode = ynca.TunSearchMode.PRESET
 
     # Preset selected
     mock_ynca.tun.preset = 16
     assert mp_entity.extra_state_attributes is not None
     assert mp_entity.extra_state_attributes["preset"] == 16
 
-    # No preset selected
-    mock_ynca.tun.preset = None
+    # Not in preset search mode
+    mock_ynca.tun.searchmode = ynca.TunSearchMode.TUNING
     assert mp_entity.extra_state_attributes is None
 
+    # No preset available
+    mock_ynca.tun.searchmode = ynca.TunSearchMode.PRESET
+    mock_ynca.tun.preset = ynca.Preset.NO_PRESET
+    assert mp_entity.extra_state_attributes is None
+
+
+async def test_mediaplayer_extra_attributes_dab_preset(
+    mp_entity: YamahaYncaZone, mock_zone: Mock, mock_ynca: Mock
+) -> None:
+
     # Tuner (DAB/FM radio)
-    mock_ynca.tun = None  # Remove tun, unit has on or the other, not both
+    mock_zone.inp = ynca.Input.TUNER
     mock_ynca.dab = create_autospec(ynca.subunits.dab.Dab)
     mock_ynca.dab.band = ynca.BandDab.FM
-    mock_ynca.dab.fmfreq = 123.45
-    mock_ynca.dab.fmrdsprgservice = None
 
     # FM Preset selected
     mock_ynca.dab.fmpreset = 8
-    mock_ynca.dab.dabpreset = ynca.DabPreset.NO_PRESET
+    mock_ynca.dab.fmsearchmode = ynca.DabFmSearchMode.PRESET
     assert mp_entity.extra_state_attributes is not None
     assert mp_entity.extra_state_attributes["preset"] == 8
 
+    # Not in preset search mode
+    mock_ynca.dab.fmsearchmode = ynca.DabFmSearchMode.TUNING
+    assert mp_entity.extra_state_attributes is None
+
+    # No FM preset available
+    mock_ynca.dab.fmsearchmode = ynca.DabFmSearchMode.PRESET
+    mock_ynca.dab.fmpreset = ynca.FmPreset.NO_PRESET
+    assert mp_entity.extra_state_attributes is None
+
     # DAB preset selected
     mock_ynca.dab.band = ynca.BandDab.DAB
-    mock_ynca.dab.fmpreset = ynca.FmPreset.NO_PRESET
     mock_ynca.dab.dabpreset = 5
     assert mp_entity.extra_state_attributes is not None
     assert mp_entity.extra_state_attributes["preset"] == 5
 
-    # No preset selected
-    mock_ynca.dab.fmpreset = ynca.FmPreset.NO_PRESET
+    # No dab preset selected
     mock_ynca.dab.dabpreset = ynca.DabPreset.NO_PRESET
     assert mp_entity.extra_state_attributes is None
 

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -764,6 +764,7 @@ async def test_mediaplayer_mediainfo_terrestrial_radio_inputs(
 async def test_mediaplayer_extra_attributes_preset(
     mp_entity: YamahaYncaZone, mock_zone: Mock, mock_ynca: Mock
 ) -> None:
+
     # Tuner (AM/FM analog radio)
     mock_zone.inp = ynca.Input.TUNER
     mock_ynca.tun = create_autospec(ynca.subunits.tun.Tun)
@@ -772,15 +773,15 @@ async def test_mediaplayer_extra_attributes_preset(
 
     # Preset selected
     mock_ynca.tun.preset = 16
+    assert mp_entity.extra_state_attributes is not None
     assert mp_entity.extra_state_attributes["preset"] == 16
 
     # No preset selected
     mock_ynca.tun.preset = None
-    assert "preset" not in mp_entity.extra_state_attributes
+    assert mp_entity.extra_state_attributes is None
 
     # Tuner (DAB/FM radio)
-    mock_zone.inp = ynca.Input.TUNER
-    mock_ynca.tun = None  # Unit has either tun or dab, not both
+    mock_ynca.tun = None  # Remove tun, unit has on or the other, not both
     mock_ynca.dab = create_autospec(ynca.subunits.dab.Dab)
     mock_ynca.dab.band = ynca.BandDab.FM
     mock_ynca.dab.fmfreq = 123.45
@@ -789,12 +790,20 @@ async def test_mediaplayer_extra_attributes_preset(
     # FM Preset selected
     mock_ynca.dab.fmpreset = 8
     mock_ynca.dab.dabpreset = ynca.DabPreset.NO_PRESET
+    assert mp_entity.extra_state_attributes is not None
     assert mp_entity.extra_state_attributes["preset"] == 8
 
     # DAB preset selected
+    mock_ynca.dab.band = ynca.BandDab.DAB
     mock_ynca.dab.fmpreset = ynca.FmPreset.NO_PRESET
     mock_ynca.dab.dabpreset = 5
+    assert mp_entity.extra_state_attributes is not None
     assert mp_entity.extra_state_attributes["preset"] == 5
+
+    # No preset selected
+    mock_ynca.dab.fmpreset = ynca.FmPreset.NO_PRESET
+    mock_ynca.dab.dabpreset = ynca.DabPreset.NO_PRESET
+    assert mp_entity.extra_state_attributes is None
 
 
 async def test_mediaplayer_media_position_duration(

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -761,6 +761,42 @@ async def test_mediaplayer_mediainfo_terrestrial_radio_inputs(
     assert mp_entity.media_content_type is MediaType.CHANNEL
 
 
+async def test_mediaplayer_extra_attributes_preset(
+    mp_entity: YamahaYncaZone, mock_zone: Mock, mock_ynca: Mock
+) -> None:
+    # Tuner (AM/FM analog radio)
+    mock_zone.inp = ynca.Input.TUNER
+    mock_ynca.tun = create_autospec(ynca.subunits.tun.Tun)
+    mock_ynca.tun.band = ynca.BandTun.AM
+    mock_ynca.tun.amfreq = 1234
+
+    # Preset selected
+    mock_ynca.tun.preset = 16
+    assert mp_entity.extra_state_attributes["preset"] == 16
+
+    # No preset selected
+    mock_ynca.tun.preset = None
+    assert "preset" not in mp_entity.extra_state_attributes
+
+    # Tuner (DAB/FM radio)
+    mock_zone.inp = ynca.Input.TUNER
+    mock_ynca.tun = None  # Unit has either tun or dab, not both
+    mock_ynca.dab = create_autospec(ynca.subunits.dab.Dab)
+    mock_ynca.dab.band = ynca.BandDab.FM
+    mock_ynca.dab.fmfreq = 123.45
+    mock_ynca.dab.fmrdsprgservice = None
+
+    # FM Preset selected
+    mock_ynca.dab.fmpreset = 8
+    mock_ynca.dab.dabpreset = ynca.DabPreset.NO_PRESET
+    assert mp_entity.extra_state_attributes["preset"] == 8
+
+    # DAB preset selected
+    mock_ynca.dab.fmpreset = ynca.FmPreset.NO_PRESET
+    mock_ynca.dab.dabpreset = 5
+    assert mp_entity.extra_state_attributes["preset"] == 5
+
+
 async def test_mediaplayer_media_position_duration(
     hass: HomeAssistant, mock_zone_main: Mock, mock_ynca: Mock
 ) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media players now expose a derived "preset" attribute in their extra attributes for tuner inputs, applied to primary and Zone B players; selects the correct preset from the active tuner source and hides when not applicable.

* **Tests**
  * Added tests verifying preset exposure and correctness across AM/FM and DAB tuner scenarios, including presence/absence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->