### PR TITLE
Bump ynca version to 6.0.0

### DIFF
--- a/custom_components/yamaha_ynca/manifest.json
+++ b/custom_components/yamaha_ynca/manifest.json
@@ -13,7 +13,7 @@
     "ynca"
   ],
   "requirements": [
-    "ynca==5.29.0"
+    "ynca==6.0.0"
   ],
   "version": "0.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ keywords = [
 requires-python = ">=3.13"
 
 # Also update ynca version in manifest.json
-dependencies = ["ynca==5.29.0"]
+dependencies = ["ynca==6.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/mvdwetering/yamaha_ynca"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required package dependency for the Yamaha YNCA integration from version 5.29.0 to 6.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->