### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Potential fix for [https://github.com/mvdwetering/yamaha_ynca/security/code-scanning/2](https://github.com/mvdwetering/yamaha_ynca/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal required scopes for `GITHUB_TOKEN`. Since this workflow only checks out code and runs tests/validations, it does not obviously need any write access. The typical minimal safe baseline is `contents: read`.

The best single change is to add a root-level `permissions` block in `.github/workflows/validations.yaml`, just below the `on:` section and before `jobs:`. This will apply to all jobs in the workflow (currently only `validate`) and restrict the token to read-only repository contents. Concretely, insert:

```yaml
permissions:
  contents: read
```

at the root level with the same indentation level as `on:` and `jobs:`. No imports or other code changes are necessary, and existing functionality of `actions/checkout`, `hassfest`, and `hacs` validations should continue to work with read-only contents access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->