### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Create release from tag
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mvdwetering/yamaha_ynca/security/code-scanning/1](https://github.com/mvdwetering/yamaha_ynca/security/code-scanning/1)

In general, the problem is fixed by adding a `permissions:` block that explicitly restricts the `GITHUB_TOKEN` to the minimal rights needed. This can be added at the top level (applies to all jobs) or under a specific job. Here we only have one job (`release`), and it needs to be able to create a GitHub release via `gh release create`, which requires `contents: write`. It doesn’t need broader scopes like `actions`, `issues`, `pull-requests`, etc.

The best minimal fix without changing existing functionality is:

- Add a workflow-level `permissions:` block directly under `name:` that grants `contents: write`.
- This ensures the job can still create releases while restricting all other scopes to none by default.

Concretely, edit `.github/workflows/release.yaml` near the top:

- After line 1 (`name: Create release from tag`), insert:
  ```yaml
  permissions:
    contents: write
  ```
No additional imports, methods, or definitions are required; this is purely a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
