### PR TITLE
Extend preset extra state attribute to SIRIUS subunit

### DIFF
--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -257,6 +257,12 @@ class YamahaYncaZone(MediaPlayerEntity):
                     and input_subunit.dabpreset is not ynca.DabPreset.NO_PRESET
                 ):
                     extra["preset"] = input_subunit.dabpreset
+            elif isinstance(input_subunit, ynca.Sirius):
+                if (
+                    input_subunit.searchmode is ynca.SiriusSearchMode.PRESET
+                    and input_subunit.preset is not ynca.Preset.NO_PRESET
+                ):
+                    extra["preset"] = input_subunit.preset
 
         return extra or None
 

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -822,6 +822,33 @@ async def test_mediaplayer_extra_attributes_dab_preset(
     assert mp_entity.extra_state_attributes is None
 
 
+async def test_mediaplayer_extra_attributes_sirius_preset(
+    mp_entity: YamahaYncaZone, mock_zone: Mock, mock_ynca: Mock
+) -> None:
+
+    # SIRIUS satellite radio
+    mock_zone.inp = ynca.Input.SIRIUS
+    mock_ynca.sirius = create_autospec(ynca.subunits.sirius.Sirius)
+    mock_ynca.sirius.searchmode = ynca.SiriusSearchMode.PRESET
+
+    # Preset selected
+    mock_ynca.sirius.preset = 5
+    assert mp_entity.extra_state_attributes is not None
+    assert mp_entity.extra_state_attributes["preset"] == 5
+
+    # Not in preset search mode
+    mock_ynca.sirius.searchmode = ynca.SiriusSearchMode.ALL_CH
+    assert mp_entity.extra_state_attributes is None
+
+    mock_ynca.sirius.searchmode = ynca.SiriusSearchMode.CATEGORY
+    assert mp_entity.extra_state_attributes is None
+
+    # No preset available
+    mock_ynca.sirius.searchmode = ynca.SiriusSearchMode.PRESET
+    mock_ynca.sirius.preset = ynca.Preset.NO_PRESET
+    assert mp_entity.extra_state_attributes is None
+
+
 async def test_mediaplayer_media_position_duration(
     hass: HomeAssistant, mock_zone_main: Mock, mock_ynca: Mock
 ) -> None:


### PR DESCRIPTION
## Summary

Extends the `preset` extra state attribute in the media player to cover the SIRIUS subunit, following the same pattern already used for TUN and DAB.

## Changes

- **`media_player.py`**: Added `elif isinstance(input_subunit, ynca.Sirius)` branch in `extra_state_attributes`. Shows `preset` when `searchmode is SiriusSearchMode.PRESET` and the preset is not `NO_PRESET`.
- **`test_media_player.py`**: Added `test_mediaplayer_extra_attributes_sirius_preset` covering: preset shown when in PRESET mode, nothing shown for ALL_CH/CATEGORY modes, nothing shown when `NO_PRESET`.

## Notes

- `SiriusSearchMode` (values: `ALL_CH`, `CATEGORY`, `PRESET`) was added to the `ynca` package in 6.1.0.
- Only `ynca.Sirius` has `searchmode` + `preset`; `SiriusIr` and `SiriusXm` do not need handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added preset attribute display for Sirius inputs when in PRESET mode, bringing feature parity with other input types.

* **Tests**
  * Added test coverage for Sirius preset functionality to ensure attributes are properly populated and handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->