### PR TITLE
Improve disconnect handling

### DIFF
--- a/custom_components/yamaha_ynca/__init__.py
+++ b/custom_components/yamaha_ynca/__init__.py
@@ -227,13 +227,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: YamahaYncaConfigEntry) -
         LOGGER.info("%s disconnected", entry.title)
 
         # Reload the entry on disconnect.
-        # HA will take care of re-init and retries
-        # OperationNotAllowed => Can not reload during setup, which is fine, so just let it go
-        # UnknownEntry => Can happen when entry was removed while trying to connect and connection fails
-        with contextlib.suppress(OperationNotAllowed, UnknownEntry):  # pragma: no cover
-            asyncio.run_coroutine_threadsafe(
-                hass.config_entries.async_reload(entry.entry_id), hass.loop
-            ).result()
+        # HA will take care of re-init and retries with backoff
+        hass.add_job(hass.config_entries.async_schedule_reload, entry.entry_id)
 
     ynca_receiver = ynca.YncaApi(
         entry.data[CONF_SERIAL_URL],

--- a/custom_components/yamaha_ynca/__init__.py
+++ b/custom_components/yamaha_ynca/__init__.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 from functools import partial
 from importlib.metadata import version
 import re
 import threading
 from typing import TYPE_CHECKING
 
-from homeassistant.config_entries import ConfigEntry, OperationNotAllowed, UnknownEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -279,6 +279,7 @@ async def test_reload_on_disconnect(
     await hass.async_block_till_done()
 
     assert len(async_reload_mock.mock_calls) == 1
+    assert async_reload_mock.call_args.args[0] == integration.entry.entry_id
 
 
 async def test_update_configentry(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Yamaha YNCA receiver disconnect handling by switching reloads to a non-blocking, scheduled approach, reducing blocking during disconnects and improving responsiveness.
  * Removed prior suppression of certain reload-time errors so failures are surfaced rather than silently ignored.

* **Tests**
  * Added a test assertion to verify a reload is requested with the integration entry identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->