### PR TITLE
Bump ynca version to 6.2.0

### DIFF
--- a/custom_components/yamaha_ynca/manifest.json
+++ b/custom_components/yamaha_ynca/manifest.json
@@ -13,7 +13,7 @@
     "ynca"
   ],
   "requirements": [
-    "ynca==6.1.0"
+    "ynca==6.2.0"
   ],
   "version": "0.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ keywords = [
 requires-python = ">=3.13"
 
 # Also update ynca version in manifest.json
-dependencies = ["ynca==6.1.0"]
+dependencies = ["ynca==6.2.0"]
 
 [project.urls]
 Documentation = "https://github.com/mvdwetering/yamaha_ynca"


### PR DESCRIPTION
Release notes: https://github.com/mvdwetering/ynca/releases/tag/v6.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying package dependency to version 6.2.0 for the Yamaha receiver integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->