### PR TITLE
Trim whitespace from media metadata properties

### DIFF
--- a/custom_components/yamaha_ynca/media_player.py
+++ b/custom_components/yamaha_ynca/media_player.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import contextlib
+from functools import wraps
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import media_source
@@ -51,6 +53,19 @@ if TYPE_CHECKING:  # pragma: no cover
 STRAIGHT = "Straight"
 
 SUPPORTED_MEDIA_ID_TYPES = ["dabpreset", "fmpreset", "preset"]
+
+
+def _trim_whitespace(
+    func: Callable[..., str | None],
+) -> Callable[..., str | None]:
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> str | None:
+        value = func(*args, **kwargs)
+        if value and (stripped := value.strip()):
+            return stripped
+        return None
+
+    return wrapper
 
 
 async def async_setup_entry(
@@ -257,12 +272,11 @@ class YamahaYncaZone(MediaPlayerEntity):
                     and input_subunit.dabpreset is not ynca.DabPreset.NO_PRESET
                 ):
                     extra["preset"] = input_subunit.dabpreset
-            elif isinstance(input_subunit, ynca.Sirius):
-                if (
-                    input_subunit.searchmode is ynca.SiriusSearchMode.PRESET
-                    and input_subunit.preset is not ynca.Preset.NO_PRESET
-                ):
-                    extra["preset"] = input_subunit.preset
+            elif isinstance(input_subunit, ynca.Sirius) and (
+                input_subunit.searchmode is ynca.SiriusSearchMode.PRESET
+                and input_subunit.preset is not ynca.Preset.NO_PRESET
+            ):
+                extra["preset"] = input_subunit.preset
 
         return extra or None
 
@@ -541,6 +555,7 @@ class YamahaYncaZone(MediaPlayerEntity):
         return None
 
     @property
+    @_trim_whitespace
     def media_title(self) -> str | None:
         """Title of current playing media."""
         if subunit := self._get_input_subunit():
@@ -556,6 +571,7 @@ class YamahaYncaZone(MediaPlayerEntity):
         return None
 
     @property
+    @_trim_whitespace
     def media_artist(self) -> str | None:
         """Artist of current playing media, music track only."""
         if (subunit := self._get_input_subunit()) and (
@@ -565,6 +581,7 @@ class YamahaYncaZone(MediaPlayerEntity):
         return None
 
     @property
+    @_trim_whitespace
     def media_album_name(self) -> str | None:
         """Album name of current playing media, music track only."""
         if (subunit := self._get_input_subunit()) and (
@@ -574,6 +591,7 @@ class YamahaYncaZone(MediaPlayerEntity):
         return None
 
     @property
+    @_trim_whitespace
     def media_channel(self) -> str | None:  # noqa: PLR0911
         """Channel currently playing."""
         subunit = self._get_input_subunit()

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -659,6 +659,22 @@ async def test_mediaplayer_mediainfo(
     assert mp_entity.media_title == "Song title"
     assert mp_entity.media_content_type is MediaType.MUSIC
 
+    # Whitespace-only metadata is not exposed
+    mock_ynca.usb.album = "   "
+    mock_ynca.usb.artist = "   "
+    mock_ynca.usb.song = "   "
+    assert mp_entity.media_album_name is None
+    assert mp_entity.media_artist is None
+    assert mp_entity.media_title is None
+
+    # Metadata with leading/trailing whitespace is stripped
+    mock_ynca.usb.album = "  AlbumName  "
+    mock_ynca.usb.artist = "  ArtistName  "
+    mock_ynca.usb.song = "  Song title  "
+    assert mp_entity.media_album_name == "AlbumName"
+    assert mp_entity.media_artist == "ArtistName"
+    assert mp_entity.media_title == "Song title"
+
     # Spotify uses Track for song titles
     mock_zone.inp = ynca.Input.SPOTIFY
     mock_ynca.spotify = create_autospec(ynca.subunits.spotify.Spotify)
@@ -690,6 +706,14 @@ async def test_mediaplayer_mediainfo_internet_radio_inputs(
     assert mp_entity.media_channel == "StationName"
     assert mp_entity.media_album_name == "AlbumName"
     assert mp_entity.media_content_type is MediaType.CHANNEL
+
+    # Whitespace in channel/station metadata is stripped
+    mock_ynca.netradio.station = "  StationName  "
+    mock_ynca.netradio.song = "  SongName  "
+    mock_ynca.netradio.album = "  AlbumName  "
+    assert mp_entity.media_title == "SongName"
+    assert mp_entity.media_channel == "StationName"
+    assert mp_entity.media_album_name == "AlbumName"
 
     # Sirius subunits expose name by the "chname" attribute
     mock_zone.inp = ynca.Input.SIRIUS_IR


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media metadata properties (title, artist, album, channel) now properly trim whitespace and return `None` for empty values instead of displaying blank strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->