### PR TITLE
Update README to clarify preset attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The mediaplayer entity supports:
 * Soundmode selection
 * Control playback state (depends on source)
 * Provide metadata like artist name, album name, song name (depends on source)
-* Exposes extra attribute with current preset when one is active
+* Exposes extra attribute "preset" when one is active
 
 #### Number
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified the Mediaplayer entity documentation to explicitly specify the "preset" attribute that is exposed when a preset is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->