### PR TITLE
Add integration_type to manifest

### DIFF
--- a/custom_components/yamaha_ynca/manifest.json
+++ b/custom_components/yamaha_ynca/manifest.json
@@ -7,6 +7,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/mvdwetering/yamaha_ynca",
+  "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mvdwetering/yamaha_ynca/issues",
   "loggers": [


### PR DESCRIPTION
Add `"integration_type": "device"` to the manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration metadata configuration for the Yamaha YNCA custom component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->