### PR TITLE
Add all zones power switch entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To report bugs or request features please [submit an issue on GitHub](https://gi
 
 The table of working models below is based on reports from users and info found on the internet. Model years were taken from the [Yamaha AVR model history page](https://kane.site44.com/Yamaha/Yamaha_AVR_model_history.html).
 
-Based on this information, receivers in the mentioned series from 2010 onwards are likely to work. So even if your model is not listed. Just give it a try.
+Based on this information, receivers in the mentioned series from 2010 onwards are likely to work. So even if your model is not listed, just give it a try.
 It has been confirmed that older receivers like the RX-V3900 from 2009 do _not_ work with this integration as it uses a different protocol. [This repo](https://github.com/jebbgrenham/yamaha-YNC) has some templates/automations that might help with those older models.
 
 If your receiver works but is not in the list, please post a message in the [discussions](https://github.com/mvdwetering/yamaha_ynca/discussions) so it can be added.
@@ -656,7 +656,7 @@ The receiver pushes updates directly to Home Assistant so entity states will upd
 
 The receiver can only accept 1 connection for the YNCA protocol that this integration uses. This means that is not possible to connect to the same receiver from multiple Home Assistant instances at the same time.
 
-It is possible to have multiple Yamaha (YCNA) integration instances connecting to multiple different receivers in a single Home Assistant instance. The limitation is on the receiver side.
+It is possible to have multiple Yamaha (YNCA) integration instances connecting to multiple different receivers in a single Home Assistant instance. The limitation is on the receiver side.
 
 It is also still possible to use other protocols to control the receiver. For example the Yamaha AV Control App will still work at same time as this integration is active.
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Yamaha (YNCA) is a custom integration for Home Assistant to support [Yamaha AV r
 
 This integration can be used to control your receiver in automations. E.g. to turn on/off other equipment when the receiver turns on/off or to set specific sound modes depending on the content that is playing (content details need to be provided by other integrations).
 
-For issues or feature requests please [submit an issue on GitHub](https://github.com/mvdwetering/yamaha_ynca/issues)
+To report bugs or request features please [submit an issue on GitHub](https://github.com/mvdwetering/yamaha_ynca/issues)
 
 ## Working models
 
 The table of working models below is based on reports from users and info found on the internet. Model years were taken from the [Yamaha AVR model history page](https://kane.site44.com/Yamaha/Yamaha_AVR_model_history.html).
 
-Based on this information, receivers in the mentioned series from 2010 onwards are likely to work. So even if your model is not listed, just give it a try.
-It has been confirmed that older receivers like the RX-V3900 from 2009 do _not_ work with this integration (it uses a different protocol). [This repo](https://github.com/jebbgrenham/yamaha-YNC) has some templates/automations that might help with those older models.
+Based on this information, receivers in the mentioned series from 2010 onwards are likely to work. So even if your model is not listed. Just give it a try.
+It has been confirmed that older receivers like the RX-V3900 from 2009 do _not_ work with this integration as it uses a different protocol. [This repo](https://github.com/jebbgrenham/yamaha-YNC) has some templates/automations that might help with those older models.
 
 If your receiver works but is not in the list, please post a message in the [discussions](https://github.com/mvdwetering/yamaha_ynca/discussions) so it can be added.
 
@@ -99,7 +99,7 @@ The mediaplayer entity supports:
 * Mute/Unmute
 * Volume control (there is a separate [number entity with Volume in dB](#volume-db-entity) if you prefer the dB unit)
 * Source selection
-  * Source names are taken from the receiver if possible (only on older models)
+  * Source names are taken from the receiver if possible (works only on older models)
   * External inputs:
     AUDIO, AUDIO1-AUDIO5, AV1-AV7, CD, COAXIAL1-COAXIAL2, DOCK, HDMI1-HDMI7, LINE1-LINE3, MULTI CH, OPTICAL1-OPTICAL2, PHONO, TV, USB, V-AUX
   * Media sources:
@@ -132,7 +132,7 @@ The mediaplayer entity supports:
 
 * Source (default disabled)
 
-The normal way to automate on the source of the receiver is through the `source` attribute on the `media_player` entity. But the source on the Main zone can also be changed with the remote control even when the receiver is Off. This is useful when you sometimes use audio from the TV and from the receiver at other times. Home Assistant hides the `source` attribute on the `media_player` entity when the receiver Off, so it can't be used in automations. This sensor is added for the specific use-case of automating on source changes when the receiver is Off.
+The standard way to automate on the source of the receiver is through the `source` attribute on the `media_player` entity. But the source on the Main zone can also be changed with the remote control even when the receiver is Off. This is useful when you sometimes use audio from the TV and from the receiver at other times. Home Assistant hides the `source` attribute on the `media_player` entity when the receiver Off, so it can't be used in automations. This sensor is added for the specific use-case of automating on source changes when the receiver is Off.
 
 #### Switch
 
@@ -604,14 +604,14 @@ cards:
 
 ### Volume (dB) entity
 
-The "Volume (dB)" entity was added to simplify volume control in Home Assistant. It is a number entity that controls the volume of a zone, like the volume in the media_player, but using the familiar dB unit instead of the percent numbers.
+The "Volume (dB)" entity was added to simplify volume control in Home Assistant. It is a number entity that controls the volume of a zone, like the volume in the media_player, but using the familiar dB unit as shown on the receiver instead of the percent numbers.
 
 <details>
 <summary>
 Background
 </summary>
 
-The volume of a `media_player` entity in Home Assistant has to be in the range 0-to-1 (shown as 0-100% in the dashboard). The range of a Yamaha receiver is typically -80.5dB to 16.5dB and is shown in the dB unit on the display/overlay. To provide the full volume range to Home Assistant this integration maps the full dB range onto the 0-to-1 range in Home Assistant. However, this makes controlling volume in Home Assistant difficult because the Home Assistant numbers are not easily convertible to the dB numbers as shown by the receiver.
+The volume of a `media_player` entity in Home Assistant has to be in the range 0-to-1 (shown as 0-100% in the dashboard). The range of a Yamaha receiver is typically -80.5dB to 16.5dB and is shown in the dB unit on the display/overlay. To provide the  volume range to Home Assistant this integration maps the full dB range onto the 0-to-1 range in Home Assistant. However, this makes controlling volume in Home Assistant difficult because the Home Assistant numbers are not easily convertible to the dB numbers as shown by the receiver.
 </details>
 
 ### Presets
@@ -622,7 +622,7 @@ Presets can be selected in the mediabrowser of the mediaplayer or in automations
 
 Due to limitations on the protocol the integration can only show the preset number, no name or what is stored.
 
-For AM/FM/DAB tuner the current preset is available as an attribute on the `media_player` entity. The attribute will not be there if no preset is active, e.g. manual tuning.
+For AM/FM/DAB tuner the current preset is available as an attribute on the `media_player` entity. The attribute will not be there if no preset is active, e.g. after manual tuning.
 
 #### Manage presets
 
@@ -656,7 +656,7 @@ The receiver pushes updates directly to Home Assistant so entity states will upd
 
 The receiver can only accept 1 connection for the YNCA protocol that this integration uses. This means that is not possible to connect to the same receiver from multiple Home Assistant instances at the same time.
 
-It is possible to have multiple Yamaha (YCNA) instances connecting to multiple different receivers in a single Home Assistant instance. The limitation is on the receiver side.
+It is possible to have multiple Yamaha (YCNA) integration instances connecting to multiple different receivers in a single Home Assistant instance. The limitation is on the receiver side.
 
 It is also still possible to use other protocols to control the receiver. For example the Yamaha AV Control App will still work at same time as this integration is active.
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The normal way to automate on the source of the receiver is through the `source`
 Following switch entities allow enable/disable of the related feature.
 
 * Adaptive DRC
+* All zones power
 * CINEMA DSP 3D mode
 * Compressed Music Enhancer
 * Direct / Pure Direct

--- a/custom_components/yamaha_ynca/switch.py
+++ b/custom_components/yamaha_ynca/switch.py
@@ -49,6 +49,8 @@ class YncaSwitchEntityDescription(SwitchEntityDescription):
     Callable to check support for this entity on the zone, default checks if attribute `key` is not None.
     This _only_ works for Zone entities, not SYS.
     """
+    availability_check: Callable[[], bool] | None = None
+    """Optional availability override."""
 
     def is_supported(self, zone_subunit: ZoneBase) -> bool:
         return self.supported_check(self, zone_subunit)
@@ -167,6 +169,15 @@ SYS_ENTITY_DESCRIPTIONS = [
         on=ynca.Party.ON,
         off=ynca.Party.OFF,
         associated_zone_attr="main",
+    ),
+    YncaSwitchEntityDescription(
+        key="pwr",
+        translation_key="all_zones_power",
+        icon="mdi:power",
+        on=ynca.Pwr.ON,
+        off=ynca.Pwr.STANDBY,
+        associated_zone_attr="main",
+        availability_check=lambda: True,
     ),
 ]
 
@@ -291,6 +302,12 @@ class YamahaYncaSwitch(YamahaYncaSettingEntity, SwitchEntity):  # type: ignore[m
             getattr(self._subunit, self.entity_description.key, None)
             == self.entity_description.on
         )
+
+    @property
+    def available(self) -> bool:
+        if self.entity_description.availability_check:
+            return self.entity_description.availability_check()
+        return super().available
 
     def turn_on(self, **_kwargs: Any) -> None:
         """Turn the entity on."""

--- a/custom_components/yamaha_ynca/translations/en.json
+++ b/custom_components/yamaha_ynca/translations/en.json
@@ -151,6 +151,9 @@
       "hdmiout2": {
         "name": "HDMI Out 2"
       },
+      "all_zones_power": {
+        "name": "All zones power"
+      },
       "party": {
         "name": "Party mode"
       },

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -35,6 +35,15 @@ TEST_ENTITY_DESCRIPTION_ASSOCIATED_ZONE = YncaSwitchEntityDescription(
     associated_zone_attr="main",
 )
 
+TEST_ENTITY_DESCRIPTION_SYS_PWR = YncaSwitchEntityDescription(
+    key="pwr",
+    name="Name",
+    on=ynca.Pwr.ON,
+    off=ynca.Pwr.STANDBY,
+    associated_zone_attr="main",
+    availability_check=lambda _subunit, _associated_zone: True,
+)
+
 TEST_ENTITY_DESCRIPTION_DIRMODE = YncaSwitchEntityDescription(
     key="dirmode",
     entity_category=EntityCategory.CONFIG,
@@ -85,7 +94,7 @@ async def test_async_setup_entry(
 
     add_entities_mock.assert_called_once()
     entities = add_entities_mock.call_args.args[0]
-    assert len(entities) == 13
+    assert len(entities) == 14
 
 
 async def test_switch_entity_fields(mock_zone: Mock) -> None:
@@ -135,6 +144,48 @@ async def test_switch_associated_zone_handling(
     assert entity.is_on is True
     mock_sys.hdmiout1 = ynca.HdmiOutOnOff.OFF
     assert entity.is_on is False
+
+    # Default availability behavior depends on associated zone power
+    mock_main.pwr = ynca.Pwr.ON
+    assert entity.available is True
+    mock_main.pwr = ynca.Pwr.STANDBY
+    assert entity.available is False
+
+
+async def test_sys_power_switch_stays_available_when_main_standby(
+    mock_ynca: Mock, mock_zone_main: Mock
+) -> None:
+    mock_sys = mock_ynca.sys
+    mock_main = mock_zone_main
+    mock_main.pwr = ynca.Pwr.STANDBY
+    mock_sys.pwr = ynca.Pwr.STANDBY
+
+    entity = YamahaYncaSwitch(
+        "ReceiverUniqueId", mock_sys, TEST_ENTITY_DESCRIPTION_SYS_PWR, mock_main
+    )
+
+    assert entity.available is True
+    assert entity.is_on is False
+
+    entity.turn_on()
+    assert mock_sys.pwr is ynca.Pwr.ON
+
+    entity.turn_off()
+    assert mock_sys.pwr is ynca.Pwr.STANDBY
+
+
+async def test_sys_power_switch_state_not_unavailable_when_main_standby(
+    hass: HomeAssistant, mock_ynca: Mock, mock_zone_main: Mock
+) -> None:
+    mock_ynca.main = mock_zone_main
+    mock_ynca.main.pwr = ynca.Pwr.STANDBY
+    mock_ynca.sys.pwr = ynca.Pwr.STANDBY
+
+    await setup_integration(hass, mock_ynca)
+
+    all_zones_power = hass.states.get("switch.modelname_main_all_zones_power")
+    assert all_zones_power is not None
+    assert all_zones_power.state == "off"
 
 
 async def test_hdmiout_not_supported_at_all(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -41,7 +41,7 @@ TEST_ENTITY_DESCRIPTION_SYS_PWR = YncaSwitchEntityDescription(
     on=ynca.Pwr.ON,
     off=ynca.Pwr.STANDBY,
     associated_zone_attr="main",
-    availability_check=lambda _subunit, _associated_zone: True,
+    availability_check=lambda: True,
 )
 
 TEST_ENTITY_DESCRIPTION_DIRMODE = YncaSwitchEntityDescription(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “All zones power” switch option for system-wide power control.
* **Bug Fixes**
  * Improved switch availability/state handling so system power control stays available and behaves consistently when the main zone is in standby.
* **Documentation**
  * Updated Yamaha (YNCA) integration documentation with clearer guidance for power/source behavior and refined entity descriptions.
* **Tests**
  * Expanded switch test coverage for the new system power and standby behavior scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->